### PR TITLE
optimized out the unnecessary roundtrip to postgres on every request

### DIFF
--- a/digital_asset_types/src/dao/scopes/asset.rs
+++ b/digital_asset_types/src/dao/scopes/asset.rs
@@ -281,8 +281,7 @@ pub async fn get_related_for_assets(
         .map(|asset| Pubkey::try_from(asset.ast_pubkey.clone()).unwrap_or_default())
         .collect::<Vec<_>>();
 
-    let asset_selected_maps =
-        get_asset_selected_maps(conn, rocks_db, converted_pubkeys.clone()).await?;
+    let asset_selected_maps = get_asset_selected_maps(rocks_db, converted_pubkeys.clone()).await?;
 
     let assets = converted_pubkeys
         .into_iter()
@@ -551,7 +550,6 @@ struct AssetSelectedMaps {
 }
 
 async fn get_asset_selected_maps(
-    conn: &impl ConnectionTrait,
     rocks_db: Arc<Storage>,
     asset_ids: Vec<Pubkey>,
 ) -> Result<AssetSelectedMaps, DbErr> {
@@ -562,44 +560,9 @@ async fn get_asset_selected_maps(
     let assets_owner = fetch_asset_data!(rocks_db, asset_owner_data, asset_ids);
     let assets_leaf = fetch_asset_data!(rocks_db, asset_leaf_data, asset_ids);
 
-    let query = format!("SELECT
-                    ast_pubkey,
-                    (SELECT mtd_url from metadata WHERE ast_metadata_url_id = mtd_id) AS ast_metadata_url
-                    FROM assets_v3
-                WHERE ast_pubkey IN ({});", asset_ids
+    let urls: HashMap<_, _> = assets_dynamic
         .iter()
-        .enumerate()
-        .map(|(index, _)| format!("${}", index + 1))
-        .collect::<Vec<_>>()
-        .join(", "));
-    let query_values = asset_ids
-        .iter()
-        .map(|asset_pk| {
-            Set(asset_pk.to_bytes().as_slice())
-                .into_value()
-                .ok_or(DbErr::Custom(format!(
-                    "cannot get value from asset_id: {:?}",
-                    asset_pk
-                )))
-        })
-        .collect::<Result<Vec<_>, DbErr>>()?;
-    let urls: HashMap<_, _> = conn
-        .query_all(Statement::from_sql_and_values(
-            sea_orm::DatabaseBackend::Postgres,
-            &query,
-            query_values.clone(),
-        ))
-        .await?
-        .iter()
-        .map(|q| AssetWithURL::from_query_result(q, "").unwrap())
-        .collect::<Vec<_>>()
-        .into_iter()
-        .map(|asset| {
-            (
-                bs58::encode(asset.ast_pubkey.as_slice()).into_string(),
-                asset.ast_metadata_url.unwrap_or_default(),
-            )
-        })
+        .map(|(key, asset)| (key.to_string(), asset.url.value.clone()))
         .collect();
 
     let offchain_data = rocks_db
@@ -673,7 +636,6 @@ fn asset_selected_maps_into_full_asset(
 }
 
 pub async fn get_by_ids(
-    conn: &impl ConnectionTrait,
     rocks_db: Arc<Storage>,
     asset_ids: Vec<Pubkey>,
 ) -> Result<Vec<Option<FullAsset>>, DbErr> {
@@ -688,8 +650,7 @@ pub async fn get_by_ids(
     }
 
     let unique_asset_ids: Vec<_> = unique_asset_ids_map.keys().cloned().collect();
-    let asset_selected_maps =
-        get_asset_selected_maps(conn, rocks_db, unique_asset_ids.clone()).await?;
+    let asset_selected_maps = get_asset_selected_maps(rocks_db, unique_asset_ids.clone()).await?;
 
     let mut results = vec![None; asset_ids.len()];
     for id in unique_asset_ids {

--- a/digital_asset_types/src/dapi/get_asset.rs
+++ b/digital_asset_types/src/dapi/get_asset.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use sea_orm::{DatabaseConnection, DbErr};
+use sea_orm::DbErr;
 use solana_sdk::pubkey::Pubkey;
 
 use rocks_db::Storage;
@@ -9,12 +9,8 @@ use crate::{dao::scopes, rpc::Asset};
 
 use super::common::asset_to_rpc;
 
-pub async fn get_asset(
-    db: &DatabaseConnection,
-    rocks_db: Arc<Storage>,
-    id: Pubkey,
-) -> Result<Option<Asset>, DbErr> {
-    let assets = scopes::asset::get_by_ids(db, rocks_db, vec![id]).await?;
+pub async fn get_asset(rocks_db: Arc<Storage>, id: Pubkey) -> Result<Option<Asset>, DbErr> {
+    let assets = scopes::asset::get_by_ids(rocks_db, vec![id]).await?;
 
     match &assets[0] {
         Some(asset) => asset_to_rpc(asset.clone()),

--- a/digital_asset_types/src/dapi/get_asset_batch.rs
+++ b/digital_asset_types/src/dapi/get_asset_batch.rs
@@ -1,5 +1,5 @@
 use rocks_db::Storage;
-use sea_orm::{DatabaseConnection, DbErr};
+use sea_orm::DbErr;
 use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
 
@@ -8,11 +8,10 @@ use crate::{dao::scopes, rpc::Asset};
 use super::common::asset_to_rpc;
 
 pub async fn get_asset_batch(
-    db: &DatabaseConnection,
     rocks_db: Arc<Storage>,
     ids: Vec<Pubkey>,
 ) -> Result<Vec<Option<Asset>>, DbErr> {
-    let assets = scopes::asset::get_by_ids(db, rocks_db, ids).await?;
+    let assets = scopes::asset::get_by_ids(rocks_db, ids).await?;
 
     assets
         .into_iter()

--- a/digital_asset_types/src/dapi/search_assets.rs
+++ b/digital_asset_types/src/dapi/search_assets.rs
@@ -2,7 +2,6 @@ use crate::dao::{scopes, ConversionError, SearchAssetsQuery};
 use crate::rpc::filter::AssetSorting;
 use crate::rpc::response::AssetList;
 use rocks_db::Storage;
-use sea_orm::DatabaseConnection;
 use sea_orm::DbErr;
 use solana_sdk::pubkey::Pubkey;
 use std::sync::Arc;
@@ -11,7 +10,6 @@ use super::common::asset_list_to_rpc;
 
 #[allow(clippy::too_many_arguments)]
 pub async fn search_assets(
-    db: &DatabaseConnection,
     index_client: &impl postgre_client::storage_traits::AssetPubkeyFilteredFetcher,
     rocks_db: Arc<Storage>,
     filter: SearchAssetsQuery,
@@ -43,7 +41,7 @@ pub async fn search_assets(
         .filter_map(|k| Pubkey::try_from(k.pubkey.clone()).ok())
         .collect::<Vec<Pubkey>>();
     //todo: there is an additional round trip to the db here, this should be optimized
-    let assets = scopes::asset::get_by_ids(db, rocks_db, asset_ids).await?;
+    let assets = scopes::asset::get_by_ids(rocks_db, asset_ids).await?;
     let assets = assets.into_iter().flatten().collect::<Vec<_>>();
     let (items, errors) = asset_list_to_rpc(assets);
     let total = items.len() as u32;

--- a/nft_ingester/src/api/api_impl.rs
+++ b/nft_ingester/src/api/api_impl.rs
@@ -179,7 +179,7 @@ impl DasApi {
         let latency_timer = Instant::now();
 
         let id = validate_pubkey(payload.id.clone())?;
-        let res = get_asset(&self.db_connection, self.rocks_db.clone(), id)
+        let res = get_asset(self.rocks_db.clone(), id)
             .await
             .map_err(Into::<DasApiError>::into)?;
 
@@ -214,7 +214,7 @@ impl DasApi {
             .map(validate_pubkey)
             .collect::<Result<Vec<_>, _>>()?;
 
-        let res = get_asset_batch(&self.db_connection, self.rocks_db.clone(), ids)
+        let res = get_asset_batch(self.rocks_db.clone(), ids)
             .await
             .map_err(Into::<DasApiError>::into)?;
 
@@ -403,7 +403,6 @@ impl DasApi {
         let query: SearchAssetsQuery = payload.clone().try_into()?;
 
         let res = search_assets(
-            &self.db_connection,
             &self.pg_client,
             self.rocks_db.clone(),
             query,


### PR DESCRIPTION
This relates to [MET-62] when we did not keep the metadata url on the dynamic details and had to do an additional roundtrip through postgres. Now that's obsolete and we may save that roundtrip. This may be optimised further code-wise, but good for now. 