### PR TITLE
RPC interface changed back and cycle added to fetch all signatures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,14 +788,13 @@ dependencies = [
  "flatbuffers",
  "futures",
  "interface",
- "mockall 0.12.0",
  "plerkle_serialization",
  "solana-client",
  "solana-program",
  "solana-sdk",
  "solana-transaction-status",
- "thiserror",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -3340,11 +3339,9 @@ name = "metrics-utils"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "figment",
  "hyper",
  "log",
  "prometheus-client",
- "serde",
  "thiserror",
  "tokio",
 ]

--- a/backfill_rpc/Cargo.toml
+++ b/backfill_rpc/Cargo.toml
@@ -8,8 +8,6 @@ edition = "2021"
 [dependencies]
 async-trait="0.1.74"
 futures="0.3.29"
-mockall = "0.12.0"
-thiserror = "1.0.51"
 entities = { path = "../entities" }
 solana-sdk = "~1.16"
 solana-client = "~1.16"
@@ -19,6 +17,7 @@ interface = { path = "../interface" }
 tokio = { version = "1.26.0", features = ["full"] }
 plerkle_serialization = "1.5.2"
 flatbuffers = "23.1.21"
+tracing = "0.1.40"
 
 [features]
 rpc_tests = []

--- a/interface/src/solana_rpc.rs
+++ b/interface/src/solana_rpc.rs
@@ -8,12 +8,13 @@ use solana_sdk::signature::Signature;
 #[automock]
 #[async_trait]
 pub trait TransactionsGetter: Send + Sync {
+    /// Returns all the signatures for the given address, starting from the newest signatures and going backwards up to until.
     async fn get_signatures_by_address(
         &self,
-        until: Signature,
-        before: Option<Signature>,
+        until: SignatureWithSlot,
         address: Pubkey,
     ) -> Result<Vec<SignatureWithSlot>, UsecaseError>;
+
     async fn get_txs_by_signatures(
         &self,
         signatures: Vec<Signature>,

--- a/metrics_utils/Cargo.toml
+++ b/metrics_utils/Cargo.toml
@@ -10,7 +10,5 @@ prometheus-client = "0.21.2"
 hyper = "0.14.23"
 chrono = "0.4.19"
 tokio = { version = "1.23.0" }
-figment = { version = "0.10.6", features = ["env", "toml", "yaml"] }
 thiserror = "1.0.31"
-serde = "1.0.136"
 log = "0.4.17"


### PR DESCRIPTION
moved get_signatures_by_address into the implementation of the BackfillRPC itself, while adding the cycle to get up to 50M signatures to the trait