### PR TITLE
Fix task insert

### DIFF
--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -200,6 +200,15 @@ pub async fn main() -> Result<(), IngesterError> {
                 .process_token_accs(cloned_keep_running)
                 .await;
         }));
+
+        let mut cloned_token_parser = token_accs_parser.clone();
+
+        let cloned_keep_running = keep_running.clone();
+        mutexed_tasks.lock().await.spawn(tokio::spawn(async move {
+            cloned_token_parser
+                .process_mint_accs(cloned_keep_running)
+                .await;
+        }));
     }
 
     let first_processed_slot = Arc::new(AtomicU64::new(0));


### PR DESCRIPTION
# What
This PR fixes tasks insert method. Also it drops one unnecessary token accs processor, it was duplicate
# Why
The problem happened when we received empty vector, then we tryed to create SQL command with it and as a result incorrect SQL.