### PR TITLE
Hotfix: always process the change log no matter the instruction

### DIFF
--- a/rocks-db/src/cl_items.rs
+++ b/rocks-db/src/cl_items.rs
@@ -11,7 +11,7 @@ use crate::asset::AssetLeaf;
 use crate::column::TypedColumn;
 use crate::errors::StorageError;
 use crate::key_encoders::{decode_u64_pubkey, encode_u64_pubkey};
-use crate::transaction::{CopyableChangeLogEventV1, TreeWithSeqAndSlot};
+use crate::transaction::{CopyableChangeLogEventV1, TreeUpdate};
 use crate::tree_seq::TreeSeqIdx;
 use crate::{AssetDynamicDetails, Result, Storage};
 
@@ -158,11 +158,7 @@ impl Storage {
         }
     }
 
-    pub(crate) fn save_tree_with_batch(
-        &self,
-        batch: &mut rocksdb::WriteBatch,
-        tree: TreeWithSeqAndSlot,
-    ) {
+    pub(crate) fn save_tree_with_batch(&self, batch: &mut rocksdb::WriteBatch, tree: TreeUpdate) {
         if let Err(e) = self.tree_seq_idx.put_with_batch(
             batch,
             (tree.tree, tree.seq),

--- a/rocks-db/src/transaction.rs
+++ b/rocks-db/src/transaction.rs
@@ -37,8 +37,6 @@ pub trait TransactionResultPersister: Sync + Send + 'static {
 
 #[derive(Clone, Default)]
 pub struct AssetUpdateEvent {
-    pub event: CopyableChangeLogEventV1,
-    pub slot: u64,
     pub update: Option<AssetDynamicUpdate>,
     pub static_update: Option<AssetUpdate<AssetStaticDetails>>,
     pub owner_update: Option<AssetUpdate<AssetOwner>>,
@@ -47,10 +45,11 @@ pub struct AssetUpdateEvent {
 }
 
 #[derive(Clone, Default)]
-pub struct TreeWithSeqAndSlot {
+pub struct TreeUpdate {
     pub tree: Pubkey,
     pub seq: u64,
     pub slot: u64,
+    pub event: CopyableChangeLogEventV1,
 }
 
 #[derive(Clone, Default)]
@@ -96,7 +95,7 @@ pub struct InstructionResult {
     pub update: Option<AssetUpdateEvent>,
     pub task: Option<Task>,
     pub decompressed: Option<AssetUpdate<AssetDynamicDetails>>,
-    pub tree_update: Option<TreeWithSeqAndSlot>,
+    pub tree_update: Option<TreeUpdate>,
 }
 
 impl From<AssetUpdateEvent> for InstructionResult {

--- a/rocks-db/src/transaction_client.rs
+++ b/rocks-db/src/transaction_client.rs
@@ -63,7 +63,6 @@ impl Storage {
         ix: InstructionResult,
     ) -> Result<(), StorageError> {
         if let Some(update) = ix.update {
-            self.save_changelog_with_batch(batch, &update.event, update.slot);
             if let Some(dyn_data) = update.update {
                 if let Err(e) = self.save_tx_data_and_asset_updated_with_batch(
                     batch,
@@ -125,6 +124,7 @@ impl Storage {
             }
         }
         if let Some(tree_update) = ix.tree_update {
+            self.save_changelog_with_batch(batch, &tree_update.event, tree_update.slot);
             self.save_tree_with_batch(batch, tree_update);
         }
 


### PR DESCRIPTION
## Description
No matter what the operation is we're persisting the change log and the seq.

## Motivation
The original implementation was normalized as fuck. We're making baby steps to normalizing the data handling and this is one of the required steps. 