### PR TITLE
Omit error logs for uninitialized mplx accounts

### DIFF
--- a/nft_ingester/src/message_handler.rs
+++ b/nft_ingester/src/message_handler.rs
@@ -320,8 +320,8 @@ impl MessageHandler {
                 };
             }
             Err(e) => match e {
-                BlockbusterError::AccountTypeNotImplemented => {}
-                BlockbusterError::UninitializedAccount => {} // acc with data - [0]
+                BlockbusterError::AccountTypeNotImplemented
+                | BlockbusterError::UninitializedAccount => {}
                 _ => account_parsing_error(e, account_info),
             },
         }


### PR DESCRIPTION
# What
This PR omits printing error logs in case we got uninitialized mplx account