### PR TITLE
persist missing blocks on request

### DIFF
--- a/backfill_rpc/src/block_producer.rs
+++ b/backfill_rpc/src/block_producer.rs
@@ -5,7 +5,7 @@ use interface::signature_persistence::BlockProducer;
 use solana_client::rpc_config::RpcBlockConfig;
 use solana_sdk::commitment_config::{CommitmentConfig, CommitmentLevel};
 use solana_transaction_status::{TransactionDetails, UiConfirmedBlock};
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 use tracing::error;
 use usecase::bigtable::is_bubblegum_transaction_encoded;
 
@@ -13,7 +13,11 @@ const SECONDS_TO_RETRY_GET_BLOCK: u64 = 5;
 
 #[async_trait]
 impl BlockProducer for BackfillRPC {
-    async fn get_block(&self, slot: u64) -> Result<UiConfirmedBlock, StorageError> {
+    async fn get_block(
+        &self,
+        slot: u64,
+        _backup_provider: Option<Arc<impl BlockProducer>>,
+    ) -> Result<UiConfirmedBlock, StorageError> {
         let mut counter = GET_TX_RETRIES;
 
         loop {

--- a/interface/src/signature_persistence.rs
+++ b/interface/src/signature_persistence.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::error::StorageError;
 use async_trait::async_trait;
 use entities::models::{BufferedTransaction, SignatureWithSlot};
@@ -53,5 +55,6 @@ pub trait BlockProducer: Send + Sync + 'static {
     async fn get_block(
         &self,
         slot: u64,
+        backup_provider: Option<Arc<impl BlockProducer>>,
     ) -> Result<solana_transaction_status::UiConfirmedBlock, StorageError>;
 }

--- a/nft_ingester/tests/bubblegum_tests.rs
+++ b/nft_ingester/tests/bubblegum_tests.rs
@@ -85,6 +85,7 @@ mod tests {
 
         let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
 
+        let none: Option<Arc<Storage>> = None;
         TransactionsParser::<
             DirectBlockParser<BackfillTransactionIngester, Storage>,
             Storage,
@@ -96,6 +97,7 @@ mod tests {
             1,
             slots_to_parse,
             shutdown_rx,
+            none,
         )
         .await
         .unwrap();
@@ -196,6 +198,7 @@ mod tests {
 
         let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
 
+        let none: Option<Arc<Storage>> = None;
         TransactionsParser::<
             DirectBlockParser<BackfillTransactionIngester, Storage>,
             Storage,
@@ -207,6 +210,7 @@ mod tests {
             1,
             slots_to_parse,
             shutdown_rx,
+            none,
         )
         .await
         .unwrap();

--- a/nft_ingester/tests/decompress.rs
+++ b/nft_ingester/tests/decompress.rs
@@ -88,6 +88,7 @@ mod tests {
 
         let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
 
+        let none: Option<Arc<Storage>> = None;
         TransactionsParser::<
             DirectBlockParser<BackfillTransactionIngester, Storage>,
             Storage,
@@ -99,6 +100,7 @@ mod tests {
             1,
             slots_to_parse,
             shutdown_rx,
+            none,
         )
         .await
         .unwrap();

--- a/usecase/src/bigtable.rs
+++ b/usecase/src/bigtable.rs
@@ -64,6 +64,7 @@ impl BlockProducer for BigTableClient {
     async fn get_block(
         &self,
         slot: u64,
+        _backup_provider: Option<Arc<impl BlockProducer>>,
     ) -> Result<solana_transaction_status::UiConfirmedBlock, StorageError> {
         let mut counter = GET_DATA_FROM_BG_RETRIES;
 


### PR DESCRIPTION
Somehow some slots are missing from the storage. If this happens we use the backup to try storing those again