### PR TITLE
Fix tcp receiver

### DIFF
--- a/nft_ingester/src/tcp_receiver.rs
+++ b/nft_ingester/src/tcp_receiver.rs
@@ -53,17 +53,11 @@ impl TcpReceiver {
                 return Ok(());
             }
 
-            match self.read_response(&mut stream).await {
-                Ok((bytes_read, duration, num_elements)) => {
-                    debug!(
-                        "TCP Socket: Received {} elements, {} in {:?}",
-                        num_elements, bytes_read, duration
-                    );
-                }
-                Err(e) => {
-                    error!("read_response: {}", e)
-                }
-            };
+            let (bytes_read, duration, num_elements) = self.read_response(&mut stream).await?;
+            debug!(
+                "TCP Socket: Received {} elements, {} in {:?}",
+                num_elements, bytes_read, duration
+            );
         }
     }
 


### PR DESCRIPTION
# What
This PR includes fix for TCP receiver.

# Why
With current version if TCP connection was broke it falls in endless loop where it try to `read_response`. This is what happened during snapshot parsing.

# How
Roll back to previous version. Now if connection was broke it will try to reconnect and keep going.