### PR TITLE
MTG-199: Standardize StorageError

### DIFF
--- a/grpc/src/client.rs
+++ b/grpc/src/client.rs
@@ -118,6 +118,9 @@ impl BlockProducer for Client {
             tracing::info!("Got block from backup provider for slot: {}", slot);
             return Ok(block);
         }
-        Err(StorageError::NotFound)
+
+        Err(StorageError::NotFound(format!(
+            "Cannot get block with slot: '{slot}'!"
+        )))
     }
 }

--- a/interface/src/error.rs
+++ b/interface/src/error.rs
@@ -60,12 +60,20 @@ impl From<serde_json::Error> for UsecaseError {
 //       e.g. by making fully compliant with rocks_db::error::StorageError
 #[derive(Error, Debug, PartialEq)]
 pub enum StorageError {
-    #[error("common error: {0}")]
+    #[error("Common error: {0}")]
     Common(String),
-    #[error("not found")]
-    NotFound,
+    #[error("Serialize error: {0}")]
+    Serialize(String),
+    #[error("Deserialize error: {0}")]
+    Deserialize(String),
+    #[error("Database specific error: {0}")]
+    DatabaseSpecificErr(String),
+    #[error("Not found: {0}")]
+    NotFound(String),
     #[error("CannotServiceRequest")]
     CannotServiceRequest,
+    #[error("Unknown error: {0}")]
+    Unknown(String),
 }
 
 impl From<Error> for UsecaseError {

--- a/rocks-db/src/errors.rs
+++ b/rocks-db/src/errors.rs
@@ -49,7 +49,7 @@ pub enum StorageError {
     TryFromSliceError(#[from] TryFromSliceError),
     NoAssetOwner(String),
     InvalidKeyLength,
-    NotFound,
+    NotFound(String),
     CannotServiceRequest,
     InvalidMigrationVersion(u64),
 }
@@ -63,20 +63,21 @@ impl std::fmt::Display for StorageError {
 impl From<StorageError> for interface::error::StorageError {
     fn from(val: StorageError) -> Self {
         use interface::error::StorageError as InterfaceStorageError;
+
         match val {
             StorageError::Common(s) => InterfaceStorageError::Common(s),
-            StorageError::RocksDb(e) => InterfaceStorageError::Common(e.to_string()),
-            StorageError::Serialize(e) => InterfaceStorageError::Common(e.to_string()),
+            StorageError::RocksDb(e) => InterfaceStorageError::DatabaseSpecificErr(e.to_string()),
+            StorageError::Serialize(e) => InterfaceStorageError::Serialize(e.to_string()),
             StorageError::TryFromSliceError(e) => InterfaceStorageError::Common(e.to_string()),
             StorageError::NoAssetOwner(s) => InterfaceStorageError::Common(s),
             StorageError::InvalidKeyLength => {
-                InterfaceStorageError::Common(String::from("InvalidKeyLength"))
+                InterfaceStorageError::Common(ToOwned::to_owned("InvalidKeyLength"))
             }
             StorageError::CannotServiceRequest => InterfaceStorageError::CannotServiceRequest,
             StorageError::InvalidMigrationVersion(v) => {
-                InterfaceStorageError::Common(format!("InvalidMigrationVersion: {}", v))
+                InterfaceStorageError::Common(format!("InvalidMigrationVersion: {v}"))
             }
-            StorageError::NotFound => InterfaceStorageError::Common(String::from("NotFound")),
+            StorageError::NotFound(s) => InterfaceStorageError::NotFound(s),
         }
     }
 }

--- a/rocks-db/src/raw_blocks_streaming_client.rs
+++ b/rocks-db/src/raw_blocks_streaming_client.rs
@@ -72,8 +72,9 @@ impl RawBlockGetter for Storage {
             )
             .map_err(|e| Box::new(e) as AsyncError)
             .and_then(|res| {
+                let err_msg = format!("Cannot get raw block with slot: '{slot}'!");
                 res.and_then(|r| serde_cbor::from_slice::<RawBlock>(r.as_slice()).ok())
-                    .ok_or(Box::new(StorageError::NotFound) as AsyncError)
+                    .ok_or(Box::new(StorageError::NotFound(err_msg)) as AsyncError)
             })
     }
 }


### PR DESCRIPTION
Added new variants of `StorageError`; Added `String` field inside of `NotFound` variant to provide more debug info; Minor fmt fixes

Also it would be nice to rename `rocks_db::errors::StorageError` (because this error inside of RocksDB crate, so `Storage` part is redundant), but I didn't find better name, so it would be nice to hear any proposals.