### PR TITLE
MTG-527 Clearing forked data from tree seq idx column family

### DIFF
--- a/interface/src/fork_cleaner.rs
+++ b/interface/src/fork_cleaner.rs
@@ -1,11 +1,11 @@
 use async_trait::async_trait;
-use entities::models::{ClItem, ForkedItem};
+use entities::models::ForkedItem;
 use std::collections::HashSet;
 use tokio::sync::broadcast::Receiver;
 
 #[async_trait]
-pub trait ClItemsManager {
-    fn items_iter(&self) -> impl Iterator<Item = ClItem>;
+pub trait CompressedTreeChangesManager<T> {
+    fn items_iter(&self) -> impl Iterator<Item = T>;
     async fn delete_items(&self, keys: Vec<ForkedItem>);
 }
 

--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -942,6 +942,7 @@ pub async fn main() -> Result<(), IngesterError> {
         let fork_cleaner = ForkCleaner::new(
             rocks_storage.clone(),
             rocks_storage.clone(),
+            rocks_storage.clone(),
             metrics_state.fork_cleaner_metrics.clone(),
         );
         let mut rx = shutdown_rx.resubscribe();

--- a/nft_ingester/src/fork_cleaner.rs
+++ b/nft_ingester/src/fork_cleaner.rs
@@ -1,6 +1,7 @@
-use entities::models::ForkedItem;
-use interface::fork_cleaner::{ClItemsManager, ForkChecker};
+use entities::models::{ClItem, ForkedItem};
+use interface::fork_cleaner::{CompressedTreeChangesManager, ForkChecker};
 use metrics_utils::ForkCleanerMetricsConfig;
+use rocks_db::tree_seq::TreeSeqIdxAllData;
 use std::collections::HashSet;
 use std::sync::Arc;
 use tokio::sync::broadcast::Receiver;
@@ -9,28 +10,36 @@ use tracing::info;
 const CI_ITEMS_DELETE_BATCH_SIZE: usize = 1000;
 const SLOT_CHECK_OFFSET: u64 = 1500;
 
-pub struct ForkCleaner<CM, FC>
+// 9000 slots == approximately one hour
+const MAX_DELAY_FOR_UNKNOWN_SLOT: u64 = 9000;
+
+pub struct ForkCleaner<CM, TM, FC>
 where
-    CM: ClItemsManager,
+    CM: CompressedTreeChangesManager<ClItem>,
+    TM: CompressedTreeChangesManager<TreeSeqIdxAllData>,
     FC: ForkChecker,
 {
     cl_items_manager: Arc<CM>,
+    tree_seq_idx_manager: Arc<TM>,
     fork_checker: Arc<FC>,
     metrics: Arc<ForkCleanerMetricsConfig>,
 }
 
-impl<CM, FC> ForkCleaner<CM, FC>
+impl<CM, TM, FC> ForkCleaner<CM, TM, FC>
 where
-    CM: ClItemsManager,
+    CM: CompressedTreeChangesManager<ClItem>,
+    TM: CompressedTreeChangesManager<TreeSeqIdxAllData>,
     FC: ForkChecker,
 {
     pub fn new(
         cl_items_manager: Arc<CM>,
+        tree_seq_idx_manager: Arc<TM>,
         fork_checker: Arc<FC>,
         metrics: Arc<ForkCleanerMetricsConfig>,
     ) -> Self {
         Self {
             cl_items_manager,
+            tree_seq_idx_manager,
             fork_checker,
             metrics,
         }
@@ -61,18 +70,52 @@ where
                 forked_slots.insert(cl_item.slot_updated);
             }
             if delete_items.len() >= CI_ITEMS_DELETE_BATCH_SIZE {
-                self.delete_items(&mut delete_items).await;
+                self.delete_cl_items(&mut delete_items).await;
             }
         }
         if !delete_items.is_empty() {
-            self.delete_items(&mut delete_items).await;
+            self.delete_cl_items(&mut delete_items).await;
+        }
+
+        for tree_seq in self.tree_seq_idx_manager.items_iter() {
+            if !rx.is_empty() {
+                info!("Stop iteration over tree sequence idx iterator...");
+                return;
+            }
+            if tree_seq.slot > last_slot_for_check {
+                continue;
+            }
+
+            if !all_non_forked_slots.contains(&tree_seq.slot)
+                && last_slot_for_check - tree_seq.slot > MAX_DELAY_FOR_UNKNOWN_SLOT
+            {
+                delete_items.push(ForkedItem {
+                    tree: tree_seq.tree,
+                    seq: tree_seq.seq,
+                    node_idx: 0, // doesn't matter here because we will drop values by tree and seq
+                });
+            }
+            if delete_items.len() >= CI_ITEMS_DELETE_BATCH_SIZE {
+                self.delete_tree_seq_idx_items(&mut delete_items).await;
+            }
+        }
+
+        if !delete_items.is_empty() {
+            self.delete_tree_seq_idx_items(&mut delete_items).await;
         }
         self.metrics.set_forks_detected(forked_slots.len() as i64);
     }
 
-    async fn delete_items(&self, delete_items: &mut Vec<ForkedItem>) {
+    async fn delete_cl_items(&self, delete_items: &mut Vec<ForkedItem>) {
         self.metrics.inc_by_deleted_items(delete_items.len() as u64);
         self.cl_items_manager
+            .delete_items(std::mem::take(delete_items))
+            .await;
+    }
+
+    async fn delete_tree_seq_idx_items(&self, delete_items: &mut Vec<ForkedItem>) {
+        self.metrics.inc_by_deleted_items(delete_items.len() as u64);
+        self.tree_seq_idx_manager
             .delete_items(std::mem::take(delete_items))
             .await;
     }

--- a/rocks-db/src/tree_seq.rs
+++ b/rocks-db/src/tree_seq.rs
@@ -8,6 +8,13 @@ pub struct TreeSeqIdx {
     pub slot: u64,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct TreeSeqIdxAllData {
+    pub tree: Pubkey,
+    pub seq: u64,
+    pub slot: u64,
+}
+
 impl TypedColumn for TreeSeqIdx {
     const NAME: &'static str = "TREE_SEQ_IDX";
 


### PR DESCRIPTION
# What
This PR adds additional iteration over tree_seq_idx Rocks column family for fork cleaner.
# Why
Previous implementation of fork cleaner deleted data only if there are rows in tree_seq_idx and cl_items with some slot which is absent from raw_blocks_cbor. But on production servers we've got in situation when we have data saved to tree_seq_idx with slots which are absent at raw_blocks_cbor and cl_items. As a result there are some trees which are "inconsistent" and we cannot back it up because slots which we are trying to download does not exist, it was fork.

Not sure yet how exactly it could happen that we have rows only in tree_seq_idx but in cl_items. One theory is that Solana node sent to the Geyser some old transactions. And such as in cl_items we use merge func to insert data we didn't save that update because it has old tree sequence. But for tree_seq_idx we use put operation to save data, and we cannot use merge because we clear that column family from time to time, when tree is fully synced.
# How
Now we will iterate over tree_seq_idx during fork clearing and check if that slots are in raw_blocks_cbor. Also we check that slots from tree_seq_idx are older that one hour from max block from raw_blocks_cbor. It's buffer time we give to backfiller to download block.