### PR TITLE
MTG-374 Make consistency checks on API optional

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,8 @@ API_RUN_PROFILING=false
 API_PROFILING_FILE_PATH_CONTAINER="/usr/src/profiling"
 API_JSON_MIDDLEWARE_CONFIG='{is_enabled=true, max_urls_to_parse=10}'
 API_ARCHIVES_DIR="/rocksdb/_rocksdb_backup_archives"
+API_CONSISTENCE_SYNCHRONIZATION_API_THRESHOLD=1_000_000
+API_CONSISTENCE_BACKFILLING_SLOTS_THRESHOLD=500
 
 # Synchronizer instance config
 SYNCHRONIZER_DATABASE_CONFIG='{max_postgres_connections=100, url="postgres://solana:solana@compressed-nft-indexer_db_1:5432/solana"}'

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -301,21 +301,13 @@ pub struct ApiConfig {
     pub max_page_limit: usize,
     pub json_middleware_config: Option<JsonMiddlewareConfig>,
     pub archives_dir: String,
-    #[serde(default = "default_synchronization_api_threshold")]
-    pub consistence_synchronization_api_threshold: u64,
+    pub consistence_synchronization_api_threshold: Option<u64>,
     #[serde(default = "default_heap_path")]
     pub heap_path: String,
-    #[serde(default = "default_consistence_backfilling_slots_threshold")]
-    pub consistence_backfilling_slots_threshold: u64,
+    pub consistence_backfilling_slots_threshold: Option<u64>,
     pub storage_service_base_url: Option<String>,
 }
 
-const fn default_synchronization_api_threshold() -> u64 {
-    1_000_000
-}
-const fn default_consistence_backfilling_slots_threshold() -> u64 {
-    500
-}
 fn default_heap_path() -> String {
     "/usr/src/app/heaps".to_string()
 }


### PR DESCRIPTION
# What
This PR makes consistency checks on API side optional.
# Why
In devnen we cannot backfill whole the transactions history and because of that API does not return any info about some assets which are from incosistent trees, even simple getAsset may not work.
# How
Make a few config parameters optional. Now we can even turn on only one consistency checks(if we ever need it)