### PR TITLE
MTG-683 Use BackfillSource in raw_backfiller

### DIFF
--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -411,7 +411,14 @@ pub async fn main() -> Result<(), IngesterError> {
     ));
     let tx_ingester = Arc::new(BackfillTransactionIngester::new(backfill_bubblegum_updates_processor.clone()));
     let backfiller_config = setup_config::<BackfillerConfig>(INGESTER_CONFIG_PREFIX);
-    let backfiller_source = Arc::new(BackfillSource::new(&config, &backfiller_config).await);
+    let backfiller_source = Arc::new(
+        BackfillSource::new(
+            &config.backfiller_source_mode,
+            config.rpc_host.clone(),
+            &backfiller_config.big_table_config,
+        )
+        .await,
+    );
     let backfiller =
         Arc::new(Backfiller::new(primary_rocks_storage.clone(), backfiller_source.clone(), backfiller_config.clone()));
 

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -18,7 +18,10 @@ pub const JSON_MIGRATOR_CONFIG_PREFIX: &str = "JSON_MIGRATOR_";
 
 #[derive(Deserialize, PartialEq, Debug, Clone)]
 pub struct BackfillerConfig {
+    #[serde(default)]
+    pub backfiller_source_mode: BackfillerSourceMode,
     pub big_table_config: BigTableConfig,
+    pub rpc_host: String,
     pub slot_until: Option<u64>,
     pub slot_start_from: u64,
     #[serde(default)]
@@ -494,7 +497,9 @@ mod tests {
         assert_eq!(
             config,
             BackfillerConfig {
+                backfiller_source_mode: BackfillerSourceMode::RPC,
                 big_table_config: BigTableConfig(figment::value::Dict::new()),
+                rpc_host: "".to_string(),
                 slot_until: None,
                 slot_start_from: 0,
                 backfiller_mode: BackfillerMode::IngestDirectly,
@@ -523,7 +528,9 @@ mod tests {
         assert_eq!(
             config,
             BackfillerConfig {
+                backfiller_source_mode: BackfillerSourceMode::RPC,
                 big_table_config: BigTableConfig(figment::value::Dict::new()),
+                rpc_host: "".to_string(),
                 slot_until: None,
                 slot_start_from: 0,
                 backfiller_mode: BackfillerMode::Persist,

--- a/scripts/run-ingest-persisted.sh
+++ b/scripts/run-ingest-persisted.sh
@@ -5,6 +5,10 @@ cargo b --release --package nft_ingester --bin raw_backfiller
 # This group of parameters has to be changed depending on the server where we are running it
 # or range of slots we are going to persist.
 export INGESTER_ROCKS_DB_PATH_CONTAINER="/rocksdb-data"
+# If source mode was set to RPC INGESTER_RPC_HOST will be used
+# if Bigtable INGESTER_BIG_TABLE_CONFIG
+export INGESTER_BACKFILLER_SOURCE_MODE=RPC # or Bigtable
+export INGESTER_RPC_HOST="http://sol-rpc.com"
 export INGESTER_BIG_TABLE_CONFIG='{creds="/aura/creds.json", timeout=1000}'
 export INGESTER_MIGRATION_STORAGE_PATH="/migration_storage"
 export INGESTER_METRICS_PORT=9091

--- a/scripts/run-slots-persisting.sh
+++ b/scripts/run-slots-persisting.sh
@@ -5,6 +5,10 @@ cargo b --release --package nft_ingester --bin raw_backfiller
 # This group of parameters has to be changed depending on the server where we are running it
 # or range of slots we are going to persist.
 export INGESTER_ROCKS_DB_PATH_CONTAINER="/rocksdb-data"
+# If source mode was set to RPC INGESTER_RPC_HOST will be used
+# if Bigtable INGESTER_BIG_TABLE_CONFIG
+export INGESTER_BACKFILLER_SOURCE_MODE=RPC # or Bigtable
+export INGESTER_RPC_HOST="http://sol-rpc.com"
 export INGESTER_BIG_TABLE_CONFIG='{creds="/aura/creds.json", timeout=1000}'
 export INGESTER_SLOT_UNTIL=275642000
 export INGESTER_SLOT_START_FROM=276960411


### PR DESCRIPTION
# What
This PR adds using BackfillSource struct to raw_backfiller

# Why
Now we can use Solana RPC in raw_backfiller. Before these changes we could use only BigTable