### PR TITLE
MTG-742 Move fungible assets dump to different thread

### DIFF
--- a/metrics_utils/src/lib.rs
+++ b/metrics_utils/src/lib.rs
@@ -305,10 +305,10 @@ impl SynchronizerMetricsConfig {
             .set(slot)
     }
 
-    pub fn inc_num_of_assets_iter(&self, num_of_records: u64) -> u64 {
+    pub fn inc_num_of_assets_iter(&self, label: &str, num_of_records: u64) -> u64 {
         self.full_sync_num_of_assets_iter
             .get_or_create(&MetricLabel {
-                name: "assets_iterated_over".to_string(),
+                name: label.to_string(),
             })
             .inc_by(num_of_records)
     }
@@ -329,10 +329,10 @@ impl SynchronizerMetricsConfig {
             .inc_by(num)
     }
 
-    pub fn set_file_write_time(&self, duration: f64) {
+    pub fn set_file_write_time(&self, label: &str, duration: f64) {
         self.full_sync_file_write_time
             .get_or_create(&MethodLabel {
-                method_name: "write_batch_of_data_to_file".to_string(),
+                method_name: label.to_string(),
             })
             .observe(duration);
     }
@@ -360,7 +360,7 @@ impl SynchronizerMetricsConfig {
 
         registry.register(
             "full_synchronization_num_of_assets_iter",
-            "Number of assets synchronizer already iterated over in asset_static_data CF",
+            "Number of assets synchronizer already iterated over in asset_static_data and token_accounts CFs",
             self.full_sync_num_of_assets_iter.clone(),
         );
 

--- a/metrics_utils/src/lib.rs
+++ b/metrics_utils/src/lib.rs
@@ -277,13 +277,14 @@ impl SynchronizerMetricsConfig {
             last_synchronized_slot: Family::<MetricLabel, Gauge>::default(),
 
             full_sync_num_of_assets_iter: Family::<MetricLabel, Counter>::default(),
-            full_sync_iter_over_assets_indexes: Family::<MethodLabel, Histogram>::new_with_constructor(|| {
-                Histogram::new(exponential_buckets(1.0, 1.8, 10))
-            }),
+            full_sync_iter_over_assets_indexes:
+                Family::<MethodLabel, Histogram>::new_with_constructor(|| {
+                    Histogram::new(exponential_buckets(1.0, 1.8, 10))
+                }),
             full_sync_num_of_records_written: Family::<MetricLabel, Counter>::default(),
-            full_sync_file_write_time: Family::<MethodLabel, Histogram>::new_with_constructor(|| {
-                Histogram::new(exponential_buckets(5.0, 1.8, 10))
-            }),
+            full_sync_file_write_time: Family::<MethodLabel, Histogram>::new_with_constructor(
+                || Histogram::new(exponential_buckets(5.0, 1.8, 10)),
+            ),
             full_sync_num_of_records_sent_to_channel: Family::<MetricLabel, Counter>::default(),
         }
     }

--- a/rocks-db/src/batch_client.rs
+++ b/rocks-db/src/batch_client.rs
@@ -17,9 +17,7 @@ use crate::{
     AssetAuthority, AssetDynamicDetails, AssetOwner, AssetStaticDetails, Result, Storage,
     BATCH_ITERATION_ACTION, ITERATOR_TOP_ACTION, ROCKS_COMPONENT,
 };
-use entities::models::{
-    AssetIndex, CompleteAssetDetails, FungibleToken, UpdateVersion, Updated, UrlWithStatus,
-};
+use entities::models::{AssetIndex, CompleteAssetDetails, UpdateVersion, Updated, UrlWithStatus};
 
 impl AssetUpdateIndexStorage for Storage {
     fn last_known_asset_updated_key(&self) -> Result<Option<AssetUpdatedKey>> {
@@ -251,35 +249,6 @@ impl AssetIndexReader for Storage {
                         .get(&data.collection.value)
                         .and_then(|c| c.authority.value),
                     slot_updated: data.get_slot_updated() as i64,
-                    ..Default::default()
-                };
-
-                asset_indexes.insert(asset_index.pubkey, asset_index);
-            }
-        }
-
-        for key in keys {
-            let fungible_tokens = self
-                .get_raw_token_accounts(None, Some(*key), None, None, None, None, true)
-                .await
-                .map_err(|e| StorageError::Common(e.to_string()))?
-                .into_iter()
-                .flatten()
-                .map(|ta| FungibleToken {
-                    owner: ta.owner,
-                    asset: ta.mint,
-                    balance: ta.amount,
-                    slot_updated: ta.slot_updated,
-                })
-                .collect::<Vec<_>>();
-
-            if let Some(existed_index) = asset_indexes.get_mut(key) {
-                existed_index.pubkey = *key;
-                existed_index.fungible_tokens = fungible_tokens;
-            } else {
-                let asset_index = AssetIndex {
-                    pubkey: *key,
-                    fungible_tokens,
                     ..Default::default()
                 };
 

--- a/rocks-db/src/dump_client.rs
+++ b/rocks-db/src/dump_client.rs
@@ -1,13 +1,15 @@
 use crate::{
+    column::Column,
     key_encoders::decode_pubkey,
     storage_traits::{AssetIndexReader, Dumper},
     Storage,
 };
 use async_trait::async_trait;
+use bincode::deserialize;
 use csv::WriterBuilder;
 use entities::{
     enums::{OwnerType, RoyaltyTargetType, SpecificationAssetClass, SpecificationVersions},
-    models::AssetIndex,
+    models::{AssetIndex, TokenAccount},
 };
 use hex;
 use inflector::Inflector;
@@ -17,7 +19,8 @@ use solana_sdk::pubkey::Pubkey;
 use std::{
     collections::{HashMap, HashSet},
     fs::File,
-    io::BufWriter, sync::Arc,
+    io::BufWriter,
+    sync::Arc,
 };
 use tokio::{sync::broadcast, task::JoinSet, time::Instant};
 use tokio::{sync::mpsc, task::JoinError};
@@ -132,8 +135,13 @@ impl Storage {
 
         let cloned_metrics = synchronizer_metrics.clone();
         writer_tasks.spawn_blocking(move || {
-            Self::write_to_file(assets_file_and_path, rx_cloned, shutdown_cloned, rx_assets,
-                cloned_metrics,)
+            Self::write_to_file(
+                assets_file_and_path,
+                rx_cloned,
+                shutdown_cloned,
+                rx_assets,
+                cloned_metrics,
+            )
         });
 
         let (tx_creators, rx_creators) = mpsc::channel(MPSC_BUFFER_SIZE);
@@ -166,19 +174,10 @@ impl Storage {
             )
         });
 
-        let (tx_fungible_tokens, rx_fungible_tokens) = mpsc::channel(MPSC_BUFFER_SIZE);
-        let rx_cloned = rx.resubscribe();
-        let shutdown_cloned = writer_shutdown_rx.resubscribe();
-
-        let cloned_metrics = synchronizer_metrics.clone();
-        writer_tasks.spawn_blocking(move || {
-            Self::write_to_file(
-                fungible_tokens_file_and_path,
-                rx_cloned,
-                shutdown_cloned,
-                rx_fungible_tokens,
-                cloned_metrics,
-            )
+        // dump fungible assets in separate blocking thread
+        let column: Column<TokenAccount> = Self::column(self.db.clone(), self.red_metrics.clone());
+        let fungible_assets_join = tokio::task::spawn_blocking(move || {
+            Self::dump_fungible_assets(column, fungible_tokens_file_and_path, batch_size)
         });
 
         let rx_cloned = rx.resubscribe();
@@ -191,10 +190,8 @@ impl Storage {
             tx_creators,
             tx_assets,
             tx_authority,
-            tx_fungible_tokens,
             synchronizer_metrics.clone(),
         ));
-        // }
 
         // Iteration over `asset_static_data` column via CUSTOM iterator.
         let iter = self.asset_static_data.iter_start();
@@ -213,7 +210,12 @@ impl Storage {
                     .get_asset_indexes(batch.as_ref())
                     .await
                     .map_err(|e| e.to_string())?;
-                self.red_metrics.observe_request("Synchronizer", "get_batch_of_assets", "get_asset_indexes", start);
+                self.red_metrics.observe_request(
+                    "Synchronizer",
+                    "get_batch_of_assets",
+                    "get_asset_indexes",
+                    start,
+                );
 
                 tx_indexes
                     .send(indexes)
@@ -235,12 +237,24 @@ impl Storage {
                 .get_asset_indexes(batch.as_ref())
                 .await
                 .map_err(|e| e.to_string())?;
-            self.red_metrics.observe_request("Synchronizer", "get_batch_of_assets", "get_asset_indexes", start);
+            self.red_metrics.observe_request(
+                "Synchronizer",
+                "get_batch_of_assets",
+                "get_asset_indexes",
+                start,
+            );
 
             tx_indexes
                 .send(indexes)
                 .await
                 .map_err(|e| format!("Error sending asset indexes to channel: {}", e))?;
+        }
+
+        if let Err(e) = fungible_assets_join.await {
+            error!(
+                "Error happened during fungible assets dumping: {}",
+                e.to_string()
+            );
         }
 
         // Once we iterate through all the assets in RocksDB we have to send stop signal
@@ -264,6 +278,64 @@ impl Storage {
         Ok(())
     }
 
+    fn dump_fungible_assets(
+        storage: Column<TokenAccount>,
+        file_and_path: (File, String),
+        batch_size: usize,
+    ) {
+        let buf_writer = BufWriter::with_capacity(ONE_G, file_and_path.0);
+        let mut writer = WriterBuilder::new()
+            .has_headers(false)
+            .from_writer(buf_writer);
+
+        // asset, owner, balance, slot updated
+        let mut batch: Vec<(String, String, i64, i64)> = Vec::new();
+
+        for token in storage
+            .iter_start()
+            .filter_map(|k| k.ok())
+            .filter_map(|(_, value)| deserialize::<TokenAccount>(value.to_vec().as_ref()).ok())
+        {
+            batch.push((
+                token.pubkey.to_string(),
+                token.owner.to_string(),
+                token.amount,
+                token.slot_updated,
+            ));
+
+            if batch.len() >= batch_size {
+                for rec in &batch {
+                    if let Err(e) = writer.serialize(rec).map_err(|e| e.to_string()) {
+                        error!(
+                            "Error while writing data into {:?}. Err: {:?}",
+                            file_and_path.1, e
+                        );
+                    }
+                }
+                batch.clear();
+            }
+        }
+
+        if !batch.is_empty() {
+            for rec in &batch {
+                if let Err(e) = writer.serialize(rec).map_err(|e| e.to_string()) {
+                    error!(
+                        "Error while writing data into {:?}. Err: {:?}",
+                        file_and_path.1, e
+                    );
+                }
+            }
+            batch.clear();
+        }
+
+        if let Err(e) = writer.flush().map_err(|e| e.to_string()) {
+            error!(
+                "Error happened during flushing data to {:?}. Err: {:?}",
+                file_and_path.1, e
+            );
+        }
+    }
+
     /// The `iterate_over_indexes` function is an asynchronous method responsible for iterating over a stream of asset indexes and processing them.
     /// It extracts `metadata`, `creators`, `assets`, and `authority` information from each index and sends this data to channels for further processing.
     /// The function listens to shut down signals to gracefully stop its operations.
@@ -276,12 +348,10 @@ impl Storage {
         tx_creators_cloned: tokio::sync::mpsc::Sender<(String, String, bool, i64)>,
         tx_assets_cloned: tokio::sync::mpsc::Sender<AssetRecord>,
         tx_authority_cloned: tokio::sync::mpsc::Sender<(String, String, i64)>,
-        tx_fungible_tokens_cloned: tokio::sync::mpsc::Sender<(String, String, i64, i64)>,
         synchronizer_metrics: Arc<SynchronizerMetricsConfig>,
     ) -> Result<(), JoinError> {
         let mut metadata_key_set = HashSet::new();
         let mut authorities_key_set = HashSet::new();
-        let mut fungible_tokens_key_set = HashSet::new();
 
         loop {
             // whole application is stopped
@@ -315,7 +385,8 @@ impl Storage {
                                 {
                                     error!("Error sending message: {:?}", e);
                                 }
-                                synchronizer_metrics.inc_num_of_records_sent_to_channel("metadata", 1);
+                                synchronizer_metrics
+                                    .inc_num_of_records_sent_to_channel("metadata", 1);
                             }
                         }
                     }
@@ -389,33 +460,15 @@ impl Storage {
                                 {
                                     error!("Error sending message: {:?}", e);
                                 }
-                                synchronizer_metrics.inc_num_of_records_sent_to_channel("authority", 1);
+                                synchronizer_metrics
+                                    .inc_num_of_records_sent_to_channel("authority", 1);
                             }
-                        }
-                    }
-                    for fungible_token in index.fungible_tokens {
-                        if !fungible_tokens_key_set
-                            .contains(&(fungible_token.asset, fungible_token.owner))
-                        {
-                            fungible_tokens_key_set
-                                .insert((fungible_token.asset, fungible_token.owner));
-                            if let Err(e) = tx_fungible_tokens_cloned
-                                .send((
-                                    Self::encode(fungible_token.asset),
-                                    Self::encode(fungible_token.owner),
-                                    fungible_token.balance,
-                                    fungible_token.slot_updated,
-                                ))
-                                .await
-                            {
-                                error!("Error sending message: {:?}", e);
-                            }
-                            synchronizer_metrics.inc_num_of_records_sent_to_channel("fungible_tokens", 1);
                         }
                     }
                 }
 
-                synchronizer_metrics.set_iter_over_assets_indexes(start.elapsed().as_millis() as f64);
+                synchronizer_metrics
+                    .set_iter_over_assets_indexes(start.elapsed().as_millis() as f64);
             }
         }
 

--- a/rocks-db/src/storage_traits.rs
+++ b/rocks-db/src/storage_traits.rs
@@ -105,7 +105,9 @@ impl Dumper for MockAssetIndexStorage {
         rx: &tokio::sync::broadcast::Receiver<()>,
         synchronizer_metrics: std::sync::Arc<metrics_utils::SynchronizerMetricsConfig>,
     ) -> core::result::Result<(), String> {
-        self.mock_dumper.dump_db(base_path, batch_size, rx, synchronizer_metrics).await
+        self.mock_dumper
+            .dump_db(base_path, batch_size, rx, synchronizer_metrics)
+            .await
     }
 }
 


### PR DESCRIPTION
# What
This PR moves dumping fungible assets, during full synchronization, to different blocking tokio thread.

# Why
To speed up full sync process and avoid complicated selects from RocksDB.