### PR TITLE
MTG-747 Save updates for fungible assets during regular sync

### DIFF
--- a/entities/src/models.rs
+++ b/entities/src/models.rs
@@ -69,7 +69,8 @@ pub struct AssetIndex {
     pub metadata_url: Option<UrlWithStatus>,
     pub update_authority: Option<Pubkey>,
     pub slot_updated: i64,
-    pub fungible_tokens: Vec<FungibleToken>,
+    pub fungible_asset_mint: Option<Pubkey>,
+    pub fungible_asset_balance: Option<u64>,
 }
 
 /// FungibleToken is associated token account

--- a/entities/src/models.rs
+++ b/entities/src/models.rs
@@ -73,11 +73,13 @@ pub struct AssetIndex {
 }
 
 /// FungibleToken is associated token account
-/// owner by some user
+/// owned by some user
+/// key - token account's pubkey
 /// owner - user owned this account
 /// asset - mint this account associated with
 #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Debug)]
 pub struct FungibleToken {
+    pub key: Pubkey,
     pub owner: Pubkey,
     pub asset: Pubkey,
     pub balance: i64,

--- a/migrations/8_token_acc_key.sql
+++ b/migrations/8_token_acc_key.sql
@@ -1,12 +1,16 @@
-ALTER TABLE fungible_tokens ADD COLUMN fbt_pubkey bytea NOT NULL;
+DROP TABLE fungible_tokens;
 
-ALTER TABLE fungible_tokens DROP CONSTRAINT fungible_tokens_pkey;
+-- recreate table and add fbt_pubkey
 
-ALTER TABLE fungible_tokens ADD PRIMARY KEY (fbt_pubkey);
-
-DROP INDEX IF EXISTS fungible_tokens_fbt_balance_idx;
-
-DROP INDEX IF EXISTS fungible_tokens_fbt_slot_updated_idx;
+CREATE TABLE fungible_tokens (
+    fbt_pubkey bytea NOT NULL,
+    fbt_owner bytea NOT NULL,
+    -- mint key
+    fbt_asset bytea NOT NULL,
+    fbt_balance bigint NOT NULL DEFAULT 0,
+    fbt_slot_updated bigint NOT NULL DEFAULT 0,
+    PRIMARY KEY (fbt_pubkey)
+);
 
 CREATE INDEX fungible_tokens_fbt_owner_balance_idx ON fungible_tokens(fbt_owner, fbt_balance);
 

--- a/migrations/8_token_acc_key.sql
+++ b/migrations/8_token_acc_key.sql
@@ -1,0 +1,13 @@
+ALTER TABLE fungible_tokens ADD COLUMN fbt_pubkey bytea NOT NULL;
+
+ALTER TABLE fungible_tokens DROP CONSTRAINT fungible_tokens_pkey;
+
+ALTER TABLE fungible_tokens ADD PRIMARY KEY (fbt_pubkey);
+
+DROP INDEX IF EXISTS fungible_tokens_fbt_balance_idx;
+
+DROP INDEX IF EXISTS fungible_tokens_fbt_slot_updated_idx;
+
+CREATE INDEX fungible_tokens_fbt_owner_balance_idx ON fungible_tokens(fbt_owner, fbt_balance);
+
+CREATE INDEX fungible_tokens_fbt_asset_idx ON fungible_tokens(fbt_asset);

--- a/nft_ingester/src/index_syncronizer.rs
+++ b/nft_ingester/src/index_syncronizer.rs
@@ -412,7 +412,8 @@ mod tests {
             }),
             update_authority: None,
             slot_updated: 123456,
-            fungible_tokens: vec![],
+            fungible_asset_mint: None,
+            fungible_asset_balance: None,
         }
     }
 

--- a/postgre-client/src/asset_index_client.rs
+++ b/postgre-client/src/asset_index_client.rs
@@ -608,6 +608,7 @@ impl PgClient {
         query_builder.push(table);
         query_builder.push(
             " (
+            fbt_pubkey,
             fbt_owner,
             fbt_asset,
             fbt_balance,
@@ -616,14 +617,15 @@ impl PgClient {
         );
         query_builder.push_values(fungible_tokens, |mut builder, fungible_token| {
             builder
+                .push_bind(fungible_token.key.to_bytes().to_vec())
                 .push_bind(fungible_token.owner.to_bytes().to_vec())
                 .push_bind(fungible_token.asset.to_bytes().to_vec())
                 .push_bind(fungible_token.balance)
                 .push_bind(fungible_token.slot_updated);
         });
         query_builder.push(
-            " ON CONFLICT (fbt_owner, fbt_asset) DO UPDATE SET
-            fbt_balance = EXCLUDED.fbt_balance, fbt_slot_updated = EXCLUDED.fbt_slot_updated
+            " ON CONFLICT (fbt_pubkey) DO UPDATE SET
+            fbt_balance = EXCLUDED.fbt_balance, fbt_slot_updated = EXCLUDED.fbt_slot_updated, fbt_owner = EXCLUDED.fbt_owner
             WHERE ",
         );
         query_builder.push(table);

--- a/postgre-client/src/asset_index_client.rs
+++ b/postgre-client/src/asset_index_client.rs
@@ -216,10 +216,11 @@ pub(crate) fn split_assets_into_components(asset_indexes: &[AssetIndex]) -> Asse
     let mut authorities = authorities.into_values().collect::<Vec<_>>();
     authorities.sort_by(|a, b| a.key.cmp(&b.key));
 
-    let mut fungible_tokens = vec![];
-    for asset in asset_indexes.iter() {
-        if asset.specification_asset_class == AssetSpecClass::FungibleToken {
-            fungible_tokens.push(FungibleToken {
+    let fungible_tokens = asset_indexes
+        .iter()
+        .filter(|asset| asset.specification_asset_class == AssetSpecClass::FungibleToken)
+        .map(|asset| {
+            FungibleToken {
                 key: asset.pubkey,
                 slot_updated: asset.slot_updated,
                 // it's unlikely that rows below will not be filled for fungible token
@@ -227,9 +228,9 @@ pub(crate) fn split_assets_into_components(asset_indexes: &[AssetIndex]) -> Asse
                 owner: asset.owner.unwrap_or_default(),
                 asset: asset.fungible_asset_mint.unwrap_or_default(),
                 balance: asset.fungible_asset_balance.unwrap_or_default() as i64,
-            });
-        }
-    }
+            }
+        })
+        .collect::<Vec<FungibleToken>>();
 
     AssetComponenents {
         fungible_tokens,

--- a/postgre-client/src/load_client.rs
+++ b/postgre-client/src/load_client.rs
@@ -97,6 +97,7 @@ impl PgClient {
             QueryBuilder::new("ALTER TABLE assets_v3 DISABLE TRIGGER ALL;");
         self.execute_query_with_metrics(transaction, &mut query_builder, ALTER_ACTION, "assets_v3")
             .await?;
+
         for index in [
             "assets_authority",
             "asset_creators_v3_creator",
@@ -117,9 +118,8 @@ impl PgClient {
             "assets_v3_is_frozen",
             "assets_v3_supply",
             "assets_v3_slot_updated",
+            "fungible_tokens_fbt_owner_balance_idx",
             "fungible_tokens_fbt_asset_idx",
-            "fungible_tokens_fbt_balance_idx",
-            "fungible_tokens_fbt_slot_updated_idx",
         ] {
             self.drop_index(transaction, index).await?;
         }
@@ -185,9 +185,8 @@ impl PgClient {
                 ("assets_v3_is_frozen", "assets_v3(ast_is_frozen) WHERE ast_is_frozen IS TRUE"),
                 ("assets_v3_supply", "assets_v3(ast_supply) WHERE ast_supply IS NOT NULL"),
                 ("assets_v3_slot_updated", "assets_v3(ast_slot_updated)"),
+                ("fungible_tokens_fbt_owner_balance_idx", "fungible_tokens(fbt_owner, fbt_balance)"),
                 ("fungible_tokens_fbt_asset_idx", "fungible_tokens(fbt_asset)"),
-                ("fungible_tokens_fbt_balance_idx", "fungible_tokens(fbt_balance) WHERE fbt_balance > 0"),
-                ("fungible_tokens_fbt_slot_updated_idx", "fungible_tokens(fbt_slot_updated)"),
             ]{
                 self.create_index(transaction, index, on_query_string).await?;
             }

--- a/tests/setup/src/pg.rs
+++ b/tests/setup/src/pg.rs
@@ -248,7 +248,8 @@ pub fn generate_asset_index_records(n: usize) -> Vec<AssetIndex> {
                 creator_share: 100,
             }],
             owner_type: Some(OwnerType::Single),
-            fungible_tokens: vec![],
+            fungible_asset_mint: None,
+            fungible_asset_balance: None,
         };
         asset_indexes.push(asset_index);
     }


### PR DESCRIPTION
# What
This PR adds fungible assets sync during regular synchronization. Also from now on, for fungible assets, we put two rows to index column family. And it adds new row to Postgre - asset pubkey.