### PR TITLE
MTG-780 Optional collection auth map

### DIFF
--- a/nft_ingester/src/index_syncronizer.rs
+++ b/nft_ingester/src/index_syncronizer.rs
@@ -347,7 +347,9 @@ where
         updated_keys_refs: &[Pubkey],
         metrics: Arc<SynchronizerMetricsConfig>,
     ) -> Result<(), IngesterError> {
-        let asset_indexes = primary_storage.get_asset_indexes(updated_keys_refs).await?;
+        let asset_indexes = primary_storage
+            .get_asset_indexes(updated_keys_refs, None)
+            .await?;
 
         if asset_indexes.is_empty() {
             warn!("No asset indexes found for keys: {:?}", updated_keys_refs);
@@ -492,7 +494,7 @@ mod tests {
             .mock_asset_index_reader
             .expect_get_asset_indexes()
             .once()
-            .return_once(move |_| Ok(map_of_asset_indexes));
+            .return_once(move |_, _| Ok(map_of_asset_indexes));
 
         index_storage
             .expect_update_asset_indexes_batch()
@@ -571,7 +573,7 @@ mod tests {
             .mock_asset_index_reader
             .expect_get_asset_indexes()
             .once()
-            .return_once(move |_| Ok(map_of_asset_indexes));
+            .return_once(move |_, _| Ok(map_of_asset_indexes));
 
         index_storage
             .expect_update_asset_indexes_batch()
@@ -674,7 +676,7 @@ mod tests {
             .mock_asset_index_reader
             .expect_get_asset_indexes()
             .times(2)
-            .returning(move |_| {
+            .returning(move |_, _| {
                 call_count2 += 1;
                 if call_count2 == 1 {
                     Ok(map_of_asset_indexes.clone())

--- a/rocks-db/src/batch_client.rs
+++ b/rocks-db/src/batch_client.rs
@@ -142,17 +142,17 @@ impl AssetIndexReader for Storage {
         let asset_collection_details = asset_collection_details?;
         let token_accounts_details = token_accounts_details?;
 
-        let assets_collection_pks = asset_collection_details
-            .iter()
-            .flat_map(|c| c.as_ref().map(|c| c.collection.value))
-            .collect::<Vec<_>>();
-
         let mpl_core_map = {
             // during dump creation hashmap with collection authorities will be passed
             // and during regular synchronization we should make additional select from DB
             if collection_authorities.is_some() {
                 HashMap::new()
             } else {
+                let assets_collection_pks = asset_collection_details
+                    .iter()
+                    .flat_map(|c| c.as_ref().map(|c| c.collection.value))
+                    .collect::<Vec<_>>();
+
                 self.asset_collection_data
                     .batch_get(assets_collection_pks)
                     .await?

--- a/rocks-db/src/storage_traits.rs
+++ b/rocks-db/src/storage_traits.rs
@@ -37,7 +37,11 @@ pub trait AssetUpdateIndexStorage {
 #[automock]
 #[async_trait]
 pub trait AssetIndexReader {
-    async fn get_asset_indexes(&self, keys: &[Pubkey]) -> Result<HashMap<Pubkey, AssetIndex>>;
+    async fn get_asset_indexes<'a>(
+        &self,
+        keys: &[Pubkey],
+        collection_authorities: Option<&'a HashMap<Pubkey, Pubkey>>,
+    ) -> Result<HashMap<Pubkey, AssetIndex>>;
 }
 
 #[automock]
@@ -91,8 +95,14 @@ impl AssetUpdateIndexStorage for MockAssetIndexStorage {
 
 #[async_trait]
 impl AssetIndexReader for MockAssetIndexStorage {
-    async fn get_asset_indexes(&self, keys: &[Pubkey]) -> Result<HashMap<Pubkey, AssetIndex>> {
-        self.mock_asset_index_reader.get_asset_indexes(keys).await
+    async fn get_asset_indexes<'a>(
+        &self,
+        keys: &[Pubkey],
+        collection_authorities: Option<&'a HashMap<Pubkey, Pubkey>>,
+    ) -> Result<HashMap<Pubkey, AssetIndex>> {
+        self.mock_asset_index_reader
+            .get_asset_indexes(keys, collection_authorities)
+            .await
     }
 }
 

--- a/rocks-db/tests/dump_tests.rs
+++ b/rocks-db/tests/dump_tests.rs
@@ -1,5 +1,6 @@
-use std::fs::File;
+use std::{fs::File, sync::Arc};
 
+use metrics_utils::SynchronizerMetricsConfig;
 use setup::rocks::*;
 use tempfile::TempDir;
 
@@ -32,6 +33,7 @@ async fn test_scv_export_from_rocks() {
             (fungible_tokens_file, fungible_tokens_path.clone()),
             155,
             &rx,
+            Arc::new(SynchronizerMetricsConfig::new()),
         )
         .await
         .unwrap();


### PR DESCRIPTION
# What
This PR is one more synchronizer refactor work. It adds optional hashMap to get_asset_indexes method. That map contains collection key and authority value. It's necessary only for core assets.

# Why
It should decrease number of times we query DB during asset batch processing. For full synchronization process it can save us hours(potentially).