### PR TITLE
MTG-803 Postgre deadlocks

### DIFF
--- a/nft_ingester/src/mpl_core_fee_indexing_processor.rs
+++ b/nft_ingester/src/mpl_core_fee_indexing_processor.rs
@@ -100,6 +100,8 @@ impl MplCoreFeeProcessor {
             });
         }
 
+        fees.sort_by(|a, b| a.pubkey.cmp(&b.pubkey));
+
         let begin_processing = Instant::now();
         if let Err(err) = self.storage.save_core_fees(fees).await {
             error!("save_core_fees: {}", err);

--- a/postgre-client/src/tasks.rs
+++ b/postgre-client/src/tasks.rs
@@ -121,8 +121,9 @@ impl PgClient {
 
         query_builder.push_bind(tasks_count);
 
+        // skip locked not to intersect with synchronizer work
         query_builder.push(
-            " FOR UPDATE
+            " FOR UPDATE SKIP LOCKED
             )
             UPDATE tasks t
             SET tsk_status = 'running',


### PR DESCRIPTION
# What
The goal of this PR is to fix deadlocks during synchronizer work.

# How
At the moment we have two situations with deadlocks: for core fees table, and assets with tasks.

For core fees fix is to sort valuesbefore insert.

For case with assets and tasks tables it's a bit complicated.

## Current theory is this

Such as assets table has foreign key to tasks when we insert data there transaction acquires AccessShareLock for tasks table. Then in different container we have JSON downloader which has `select ... for update` command. That command acquires ShareLock for tasks table. And here where we have a problem. Here is part of the log from Postgre: `DETAIL:  Process 720429 waits for ShareLock on transaction 52276879; blocked by process 720441.`

To fix this `FOR UPDATE` was replaced with `FOR UPDATE SKIP LOCKED`. Meaming JSON downloader will not process tasks which are in use by synchronizer at the moment. It's fine because JSON downloader will return to that tasks later anyway.