### PR TITLE
MTG-819 Add metrics for data processing time

### DIFF
--- a/metrics_utils/src/lib.rs
+++ b/metrics_utils/src/lib.rs
@@ -123,8 +123,7 @@ pub struct MetricLabelWithStatus {
 
 #[derive(Debug, Clone)]
 pub struct MessageProcessMetricsConfig {
-    accounts_read: Family<MetricLabel, Histogram>,
-    transactions_read: Family<MetricLabel, Histogram>,
+    data_read: Family<MetricLabel, Histogram>,
 }
 
 impl Default for MessageProcessMetricsConfig {
@@ -136,25 +135,14 @@ impl Default for MessageProcessMetricsConfig {
 impl MessageProcessMetricsConfig {
     pub fn new() -> Self {
         Self {
-            accounts_read: Family::<MetricLabel, Histogram>::new_with_constructor(|| {
-                Histogram::new(exponential_buckets(1.0, 1.8, 10))
-            }),
-            transactions_read: Family::<MetricLabel, Histogram>::new_with_constructor(|| {
-                Histogram::new(exponential_buckets(1.0, 1.8, 10))
+            data_read: Family::<MetricLabel, Histogram>::new_with_constructor(|| {
+                Histogram::new(exponential_buckets(1.0, 2.4, 10))
             }),
         }
     }
 
-    pub fn set_accounts_read_time(&self, label: &str, duration: f64) {
-        self.accounts_read
-            .get_or_create(&MetricLabel {
-                name: label.to_string(),
-            })
-            .observe(duration);
-    }
-
-    pub fn set_transactions_read_time(&self, label: &str, duration: f64) {
-        self.transactions_read
+    pub fn set_data_read_time(&self, label: &str, duration: f64) {
+        self.data_read
             .get_or_create(&MetricLabel {
                 name: label.to_string(),
             })
@@ -163,15 +151,9 @@ impl MessageProcessMetricsConfig {
 
     pub fn register(&self, registry: &mut Registry) {
         registry.register(
-            "accounts_data_read_time",
-            "Time pass between Geyser push accounts data to queue and ingester read it",
-            self.accounts_read.clone(),
-        );
-
-        registry.register(
-            "transactions_data_read_time",
-            "Time pass between Geyser push transactions data to queue and ingester read it",
-            self.transactions_read.clone(),
+            "data_read_time",
+            "Time pass between Geyser push data to the queue and ingester process it",
+            self.data_read.clone(),
         );
     }
 }

--- a/metrics_utils/src/lib.rs
+++ b/metrics_utils/src/lib.rs
@@ -39,6 +39,7 @@ impl IntegrityVerificationMetrics {
 
 #[derive(Debug)]
 pub struct MetricState {
+    pub message_process_metrics: Arc<MessageProcessMetricsConfig>,
     pub ingester_metrics: Arc<IngesterMetricsConfig>,
     pub api_metrics: Arc<ApiMetricsConfig>,
     pub json_downloader_metrics: Arc<JsonDownloaderMetricsConfig>,
@@ -63,6 +64,7 @@ impl Default for MetricState {
 impl MetricState {
     pub fn new() -> Self {
         Self {
+            message_process_metrics: Arc::new(MessageProcessMetricsConfig::new()),
             ingester_metrics: Arc::new(IngesterMetricsConfig::new()),
             api_metrics: Arc::new(ApiMetricsConfig::new()),
             json_downloader_metrics: Arc::new(JsonDownloaderMetricsConfig::new()),
@@ -117,6 +119,61 @@ impl fmt::Display for MetricStatus {
 pub struct MetricLabelWithStatus {
     pub name: String,
     pub status: MetricStatus,
+}
+
+#[derive(Debug, Clone)]
+pub struct MessageProcessMetricsConfig {
+    accounts_read: Family<MetricLabel, Histogram>,
+    transactions_read: Family<MetricLabel, Histogram>,
+}
+
+impl Default for MessageProcessMetricsConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl MessageProcessMetricsConfig {
+    pub fn new() -> Self {
+        Self {
+            accounts_read: Family::<MetricLabel, Histogram>::new_with_constructor(|| {
+                Histogram::new(exponential_buckets(1.0, 1.8, 10))
+            }),
+            transactions_read: Family::<MetricLabel, Histogram>::new_with_constructor(|| {
+                Histogram::new(exponential_buckets(1.0, 1.8, 10))
+            }),
+        }
+    }
+
+    pub fn set_accounts_read_time(&self, label: &str, duration: f64) {
+        self.accounts_read
+            .get_or_create(&MetricLabel {
+                name: label.to_string(),
+            })
+            .observe(duration);
+    }
+
+    pub fn set_transactions_read_time(&self, label: &str, duration: f64) {
+        self.transactions_read
+            .get_or_create(&MetricLabel {
+                name: label.to_string(),
+            })
+            .observe(duration);
+    }
+
+    pub fn register(&self, registry: &mut Registry) {
+        registry.register(
+            "accounts_data_read_time",
+            "Time pass between Geyser push accounts data to queue and ingester read it",
+            self.accounts_read.clone(),
+        );
+
+        registry.register(
+            "transactions_data_read_time",
+            "Time pass between Geyser push transactions data to queue and ingester read it",
+            self.transactions_read.clone(),
+        );
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -526,6 +583,7 @@ impl MetricsTrait for MetricState {
         self.batch_mint_processor_metrics.start_time();
 
         self.api_metrics.register(&mut self.registry);
+        self.message_process_metrics.register(&mut self.registry);
         self.ingester_metrics.register(&mut self.registry);
 
         self.json_downloader_metrics.register(&mut self.registry);

--- a/nft_ingester/src/accounts_processor.rs
+++ b/nft_ingester/src/accounts_processor.rs
@@ -241,7 +241,7 @@ impl<T: UnprocessedAccountsGetter> AccountsProcessor<T> {
                 if let Some(message_timestamp) = get_timestamp_from_id(&unprocessed_account.id) {
                     let current_timestamp = Utc::now().timestamp_millis() as u64;
 
-                    message_process_metrics.set_accounts_read_time(
+                    message_process_metrics.set_data_read_time(
                         "accounts",
                         current_timestamp
                             .checked_sub(message_timestamp)

--- a/nft_ingester/src/accounts_processor.rs
+++ b/nft_ingester/src/accounts_processor.rs
@@ -3,11 +3,13 @@ use crate::inscriptions_processor::InscriptionsProcessor;
 use crate::mpl_core_fee_indexing_processor::MplCoreFeeProcessor;
 use crate::mpl_core_processor::MplCoreProcessor;
 use crate::mplx_updates_processor::MplxAccountsProcessor;
+use crate::redis_receiver::get_timestamp_from_id;
 use crate::token_updates_processor::TokenAccountsProcessor;
+use chrono::Utc;
 use entities::enums::UnprocessedAccount;
 use entities::models::{CoreAssetFee, UnprocessedAccountMessage};
 use interface::unprocessed_data_getter::UnprocessedAccountsGetter;
-use metrics_utils::IngesterMetricsConfig;
+use metrics_utils::{IngesterMetricsConfig, MessageProcessMetricsConfig};
 use postgre_client::PgClient;
 use rocks_db::batch_savers::BatchSaveStorage;
 use rocks_db::Storage;
@@ -36,6 +38,7 @@ pub async fn run_accounts_processor<AG: UnprocessedAccountsGetter + Sync + Send 
     account_buffer_size: usize,
     fees_buffer_size: usize,
     metrics: Arc<IngesterMetricsConfig>,
+    message_process_metrics: Option<Arc<MessageProcessMetricsConfig>>,
     postgre_client: Arc<PgClient>,
     rpc_client: Arc<RpcClient>,
     join_set: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
@@ -46,6 +49,7 @@ pub async fn run_accounts_processor<AG: UnprocessedAccountsGetter + Sync + Send 
             fees_buffer_size,
             unprocessed_transactions_getter,
             metrics,
+            message_process_metrics,
             postgre_client,
             rpc_client,
             join_set,
@@ -70,6 +74,7 @@ pub struct AccountsProcessor<T: UnprocessedAccountsGetter> {
     inscription_processor: InscriptionsProcessor,
     core_fees_processor: MplCoreFeeProcessor,
     metrics: Arc<IngesterMetricsConfig>,
+    message_process_metrics: Option<Arc<MessageProcessMetricsConfig>>,
 }
 
 // AccountsProcessor responsible for processing all account updates received
@@ -84,6 +89,7 @@ impl<T: UnprocessedAccountsGetter> AccountsProcessor<T> {
         fees_batch_size: usize,
         unprocessed_account_getter: Arc<T>,
         metrics: Arc<IngesterMetricsConfig>,
+        message_process_metrics: Option<Arc<MessageProcessMetricsConfig>>,
         postgre_client: Arc<PgClient>,
         rpc_client: Arc<RpcClient>,
         join_set: Arc<Mutex<JoinSet<Result<(), tokio::task::JoinError>>>>,
@@ -106,6 +112,7 @@ impl<T: UnprocessedAccountsGetter> AccountsProcessor<T> {
             inscription_processor,
             core_fees_processor,
             metrics,
+            message_process_metrics,
         })
     }
 
@@ -229,6 +236,20 @@ impl<T: UnprocessedAccountsGetter> AccountsProcessor<T> {
             }
             self.metrics
                 .inc_accounts(unprocessed_account.account.into());
+
+            if let Some(message_process_metrics) = &self.message_process_metrics {
+                if let Some(message_timestamp) = get_timestamp_from_id(&unprocessed_account.id) {
+                    let current_timestamp = Utc::now().timestamp_millis() as u64;
+
+                    message_process_metrics.set_accounts_read_time(
+                        "accounts",
+                        current_timestamp
+                            .checked_sub(message_timestamp)
+                            .unwrap_or_default() as f64,
+                    );
+                }
+            }
+
             ack_ids.push(unprocessed_account.id);
             if batch_storage.batch_filled() {
                 self.flush(batch_storage, ack_ids, interval, batch_fill_instant);

--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -207,6 +207,7 @@ pub async fn main() -> Result<(), IngesterError> {
                     config.accounts_buffer_size,
                     config.mpl_core_fees_buffer_size,
                     metrics_state.ingester_metrics.clone(),
+                    Some(metrics_state.message_process_metrics.clone()),
                     index_pg_storage.clone(),
                     rpc_client.clone(),
                     mutexed_tasks.clone(),
@@ -222,6 +223,8 @@ pub async fn main() -> Result<(), IngesterError> {
                     config.accounts_buffer_size,
                     config.mpl_core_fees_buffer_size,
                     metrics_state.ingester_metrics.clone(),
+                    // TCP sender does not send any ids with timestamps so we may not pass message process metrics here
+                    None,
                     index_pg_storage.clone(),
                     rpc_client.clone(),
                     mutexed_tasks.clone(),
@@ -241,6 +244,8 @@ pub async fn main() -> Result<(), IngesterError> {
             config.snapshot_parsing_batch_size,
             config.mpl_core_fees_buffer_size,
             metrics_state.ingester_metrics.clone(),
+            // during snapshot parsing we don't want to collect message process metrics
+            None,
             index_pg_storage.clone(),
             rpc_client.clone(),
             mutexed_tasks.clone(),
@@ -395,6 +400,7 @@ pub async fn main() -> Result<(), IngesterError> {
                     mutexed_tasks.clone(),
                     redis_receiver,
                     geyser_bubblegum_updates_processor.clone(),
+                    Some(metrics_state.message_process_metrics.clone()),
                 )
                 .await;
             }
@@ -404,6 +410,8 @@ pub async fn main() -> Result<(), IngesterError> {
                     mutexed_tasks.clone(),
                     buffer.clone(),
                     geyser_bubblegum_updates_processor.clone(),
+                    // TCP sender does not send any ids with timestamps so we may not pass message process metrics here
+                    None,
                 )
                 .await;
             }

--- a/nft_ingester/src/redis_receiver.rs
+++ b/nft_ingester/src/redis_receiver.rs
@@ -128,3 +128,10 @@ impl UnprocessedAccountsGetter for RedisReceiver {
         }
     }
 }
+
+/// id - Redis stream data ID. Which is milliseconds timestamp
+/// id example - 1692632086370-0
+/// where `0` is message sequence which is ignored here
+pub fn get_timestamp_from_id(id: &str) -> Option<u64> {
+    id.split('-').next().and_then(|t| t.parse().ok())
+}

--- a/nft_ingester/src/transaction_processor.rs
+++ b/nft_ingester/src/transaction_processor.rs
@@ -47,7 +47,7 @@ pub async fn run_transaction_processor<TG>(
                             if let Some(message_timestamp) = get_timestamp_from_id(&tx.id) {
                                 let current_timestamp = Utc::now().timestamp_millis() as u64;
 
-                                message_process_metrics.set_transactions_read_time(
+                                message_process_metrics.set_data_read_time(
                                     "transactions",
                                     current_timestamp
                                         .checked_sub(message_timestamp)


### PR DESCRIPTION
# What
This PR adds new metrics - MessageProcessMetricsConfig.

# Why
It will allow us to see how fast indexer process data received from Geyser plugin.

# How
Metric call was added to main accounts and transactions processing functions. By main functions I mean functions where we extract data from Redis(or TCP connection), call processor and then call acknowledge. It means that during backfill processes that metrics will not be changed.