### PR TITLE
MTG-886 Change config for TCP and Redis messengers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,9 +6,11 @@ RUST_BACKTRACE=1
 INGESTER_LOG_LEVEL=info
 
 INGESTER_DATABASE_CONFIG='{max_postgres_connections=10, url="postgres://user:pass@0.0.0.0:5432/database"}'
-INGESTER_TCP_CONFIG='{receiver_addr="localhost:2000", receiver_reconnect_interval=5, snapshot_receiver_addr="localhost:5000"}'
-INGESTER_REDIS_MESSENGER_CONFIG='{messenger_type="Redis", connection_config={redis_connection_str="redis://:pass@localhost:6379"}}'
-INGESTER_MESSAGE_SOURCE=Redis #TCP or Redis
+# Messenger config may be set either for TCP or Redis data source
+# Config for TCP
+# export INGESTER_MESSENGER_CONFIG='{messenger_type=TCP, receiver_addr="0.0.0.0:2000", receiver_reconnect_interval=10}'
+# Config for Redis
+INGESTER_MESSENGER_CONFIG='{messenger_type=Redis, redis_config={redis_connection_str="redis://:pass@localhost:6379"}}'
 
 INGESTER_ACCOUNTS_BUFFER_SIZE=250
 INGESTER_ACCOUNTS_PARSING_WORKERS=20

--- a/nft_ingester/scripts/run_ingester.bash
+++ b/nft_ingester/scripts/run_ingester.bash
@@ -1,6 +1,7 @@
 export RUST_LOG=error
 export INGESTER_DATABASE_CONFIG='{max_postgres_connections=500, url="postgres://solana:solana@localhost:5432/v3"}'
-export INGESTER_TCP_CONFIG='{receiver_addr=["eq15.everstake.one:2000", "127.0.0.1:3052"], receiver_connect_timeout=10, receiver_reconnect_interval=5, backfiller_receiver_addr="127.0.0.1:3334", backfiller_receiver_connect_timeout=10, backfiller_receiver_reconnect_interval=5, backfiller_sender_port=3334, backfiller_sender_batch_max_bytes=1, backfiller_sender_buffer_size=1,snapshot_receiver_addr="127.0.0.1:3052"}'
+export INGESTER_MESSENGER_CONFIG='{"TCP": {"key1": "value1", "key2": "value2"}}'
+# export INGESTER_TCP_CONFIG='{receiver_addr=["eq15.everstake.one:2000", "127.0.0.1:3052"], receiver_connect_timeout=10, receiver_reconnect_interval=5, backfiller_receiver_addr="127.0.0.1:3334", backfiller_receiver_connect_timeout=10, backfiller_receiver_reconnect_interval=5, backfiller_sender_port=3334, backfiller_sender_batch_max_bytes=1, backfiller_sender_buffer_size=1,snapshot_receiver_addr="127.0.0.1:3052"}'
 export INGESTER_TX_BACKGROUND_SAVERS=5
 export INGESTER_BACKFILL_BACKGROUND_SAVERS=1
 export INGESTER_MPLX_BUFFER_SIZE=500


### PR DESCRIPTION
# What
This PR changes config for TCP and Redis messengers a little bit. Before these changes there were 3 different config variables for messenger, now only one.

In .env.example there is comment which describes how to write the config now.

Also main func was slightly changed. Now launching workers for accounts and transactions updates listening is more structured and defined in one place.