### PR TITLE
MTG-959 fix a few issues with core assets

### DIFF
--- a/nft_ingester/src/api/dapi/rpc_asset_convertors.rs
+++ b/nft_ingester/src/api/dapi/rpc_asset_convertors.rs
@@ -269,17 +269,20 @@ fn extract_collection_metadata(
 }
 
 pub fn to_authority(
-    authority: &AssetAuthority,
+    authority: &Option<AssetAuthority>,
     mpl_core_collection: &Option<AssetCollection>,
 ) -> Vec<Authority> {
     let update_authority = mpl_core_collection
         .clone()
         .and_then(|update_authority| update_authority.authority.value);
 
+    // even if there is no authority for asset we should not set Pubkey::default(), just empty string
+    let auth_key = update_authority
+        .map(|update_authority| update_authority.to_string())
+        .unwrap_or(authority.as_ref().map(|auth| auth.authority.to_string()).unwrap_or("".to_string()));
+
     vec![Authority {
-        address: update_authority
-            .map(|update_authority| update_authority.to_string())
-            .unwrap_or(authority.authority.to_string()),
+        address: auth_key,
         scopes: vec![Scope::Full],
     }]
 }

--- a/nft_ingester/src/api/dapi/rpc_asset_models.rs
+++ b/nft_ingester/src/api/dapi/rpc_asset_models.rs
@@ -294,7 +294,7 @@ pub struct FullAsset {
     pub asset_leaf: AssetLeaf,
     pub offchain_data: OffChainData,
     pub asset_collections: Option<AssetCollection>,
-    pub assets_authority: AssetAuthority,
+    pub assets_authority: Option<AssetAuthority>,
     pub edition_data: Option<EditionData>,
     pub mpl_core_collections: Option<AssetCollection>,
     pub collection_dynamic_data: Option<AssetDynamicDetails>,

--- a/nft_ingester/src/processors/account_based/mpl_core_processor.rs
+++ b/nft_ingester/src/processors/account_based/mpl_core_processor.rs
@@ -79,7 +79,7 @@ impl MplCoreProcessor {
         let update_authority = match asset.update_authority {
             UpdateAuthority::Address(address) => Some(address),
             UpdateAuthority::Collection(address) => storage.get_authority(address),
-            UpdateAuthority::None => Some(Pubkey::default()),
+            UpdateAuthority::None => None,
         };
 
         let name = asset.name.clone();

--- a/nft_ingester/src/processors/account_based/mpl_core_processor.rs
+++ b/nft_ingester/src/processors/account_based/mpl_core_processor.rs
@@ -14,6 +14,7 @@ use rocks_db::{AssetAuthority, AssetDynamicDetails, AssetOwner, AssetStaticDetai
 use serde_json::Map;
 use serde_json::{json, Value};
 use solana_program::pubkey::Pubkey;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Instant;
 use usecase::save_metrics::result_to_metrics;
@@ -76,9 +77,9 @@ impl MplCoreProcessor {
         // If it is an `Address` type, use the value directly.  If it is a `Collection`, search for and
         // use the collection's authority.
         let update_authority = match asset.update_authority {
-            UpdateAuthority::Address(address) => address,
+            UpdateAuthority::Address(address) => Some(address),
             UpdateAuthority::Collection(address) => storage.get_authority(address),
-            UpdateAuthority::None => Pubkey::default(),
+            UpdateAuthority::None => Some(Pubkey::default()),
         };
 
         let name = asset.name.clone();
@@ -113,7 +114,7 @@ impl MplCoreProcessor {
         let (owner, class) = match account_data.indexable_asset.clone() {
             MplCoreAccountData::Asset(_) => (asset.owner, SpecificationAssetClass::MplCoreAsset),
             MplCoreAccountData::Collection(_) => (
-                Some(update_authority),
+                update_authority,
                 SpecificationAssetClass::MplCoreCollection,
             ),
             _ => return Ok(None),
@@ -133,7 +134,14 @@ impl MplCoreProcessor {
             })
             .unwrap_or((0, &default_creators));
 
-        let mut plugins_json = serde_json::to_value(&asset.plugins)
+        // convert HashMap plugins into BTreeMap to have always same plugins order
+        // for example without ordering 2 assets with same plugins can have different order saved in DB
+        // it affects only API response and tests
+        let ordered_plugins: BTreeMap<_, _> = asset.plugins
+            .iter()
+            .map(|(key, value)| (format!("{:?}", key), value))
+            .collect();
+        let mut plugins_json = serde_json::to_value(&ordered_plugins)
             .map_err(|e| IngesterError::DeserializationError(e.to_string()))?;
 
         // Improve JSON output.
@@ -186,7 +194,7 @@ impl MplCoreProcessor {
                 .get(&PluginType::TransferDelegate)
                 .and_then(|plugin_schema| match &plugin_schema.authority {
                     PluginAuthority::Owner => owner,
-                    PluginAuthority::UpdateAuthority => Some(update_authority),
+                    PluginAuthority::UpdateAuthority => update_authority,
                     PluginAuthority::Address { address } => Some(*address),
                     PluginAuthority::None => None,
                 });
@@ -210,7 +218,7 @@ impl MplCoreProcessor {
                 account_data.indexable_asset,
                 MplCoreAccountData::Collection(_)
             ) {
-                Some(update_authority)
+                update_authority
             } else {
                 None
             };
@@ -254,12 +262,16 @@ impl MplCoreProcessor {
             created_at: account_data.slot_updated as i64,
             edition_address: None,
         });
-        models.asset_authority = Some(AssetAuthority {
-            pubkey: asset_key,
-            authority: update_authority,
-            slot_updated: account_data.slot_updated,
-            write_version: Some(account_data.write_version),
-        });
+        if let Some(upd_auth) = update_authority {
+            models.asset_authority = Some(AssetAuthority {
+                pubkey: asset_key,
+                authority: upd_auth,
+                slot_updated: account_data.slot_updated,
+                write_version: Some(account_data.write_version),
+            });
+        } else {
+            models.asset_authority = None;
+        }
         models.asset_owner = Some(AssetOwner {
             pubkey: asset_key,
             owner: Updated::new(

--- a/rocks-db/src/batch_savers.rs
+++ b/rocks-db/src/batch_savers.rs
@@ -209,7 +209,7 @@ impl BatchSaveStorage {
         )
     }
 
-    pub fn get_authority(&self, address: Pubkey) -> Pubkey {
+    pub fn get_authority(&self, address: Pubkey) -> Option<Pubkey> {
         if let Ok(Some(data)) = self.storage.db.get_pinned_cf(
             &self
                 .storage
@@ -223,10 +223,9 @@ impl BatchSaveStorage {
                 .ok()
                 .and_then(|a| a.authority())
                 .and_then(|auth| auth.authority())
-                .map(|k| Pubkey::try_from(k.bytes()).unwrap())
-                .unwrap_or_default();
+                .map(|k| Pubkey::try_from(k.bytes()).unwrap());
         }
-        Pubkey::default()
+        None
     }
 
     pub fn get_mint_map(&self, key: Pubkey) -> Result<Option<MetadataMintMap>> {

--- a/rocks-db/src/token_accounts.rs
+++ b/rocks-db/src/token_accounts.rs
@@ -154,7 +154,7 @@ pub fn merge_token_accounts(
     for op in operands {
         match deserialize::<TokenAccount>(op) {
             Ok(new_val) => {
-                if new_val.write_version > write_version {
+                if new_val.write_version > write_version || result.is_empty() {
                     write_version = new_val.write_version;
                     result = op.to_vec();
                 }
@@ -352,7 +352,7 @@ pub fn merge_mints(
     for op in operands {
         match deserialize::<SplMint>(op) {
             Ok(new_val) => {
-                if new_val.write_version > write_version {
+                if new_val.write_version > write_version || result.is_empty() {
                     write_version = new_val.write_version;
                     result = op.to_vec();
                 }


### PR DESCRIPTION
# What

This PR fixes a few issues with Core assets.

1. If there is no authority for asset it will not return system prog adress but empty string instead.

2. For Core collections API doesn't check collection verification field.

3. If there is no collection for asset `showUnverifiedCollection` flag should not affect the API response.

4. Please take a closer look at changes in `nft_ingester/src/processors/account_based/mpl_core_processor.rs`. It was made to fix plugin ordering for assets. Kinda minor stuff so maybe we don't need it because it adds convertion from HashMap to BTreeMap during asset processing time but without that change same plugins list can be shown in different order on API side.