### PR TITLE
MTG-993 Fix one integration test

### DIFF
--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -33,6 +33,6 @@ tempfile = {workspace = true}
 nft_ingester = { path = "../nft_ingester" }
 postgre-client = { path = "../postgre-client", features = ["integration_tests"] }
 metrics-utils = { path = "../metrics_utils" }
-rocks-db = { path = "../rocks-db" }
+rocks-db = { path = "../rocks-db", features = ["integration_tests"] }
 usecase = { path = "../usecase" }
 entities = { path = "../entities" }

--- a/integration_tests/src/account_update_tests.rs
+++ b/integration_tests/src/account_update_tests.rs
@@ -121,7 +121,14 @@ async fn index_account_update(setup: &TestSetup, pubkey: Pubkey, update: Account
 #[named]
 async fn test_account_updates() {
     let name = trim_test_name(function_name!());
-    let setup = TestSetup::new(name.clone()).await;
+    let setup = TestSetup::new_with_options(
+        name.clone(),
+        TestSetupOptions {
+            network: None,
+            clear_db: true,
+        },
+    )
+    .await;
     let mint = Pubkey::try_from("843gdpsTE4DoJz3ZoBsEjAqT8UgAcyF5YojygGgGZE1f").unwrap();
 
     let nft_accounts = get_nft_accounts(&setup, mint).await;
@@ -176,6 +183,8 @@ async fn test_account_updates() {
             continue;
         }
 
+        setup.clean_up_data_bases().await;
+
         index_nft(&setup, mint).await;
 
         let response = setup
@@ -228,6 +237,8 @@ async fn test_account_updates() {
     // Test that the different metadata/mint/token updates use different slots and don't interfere
     // with each other
     for named_update in named_updates.clone() {
+        setup.clean_up_data_bases().await;
+
         index_nft(&setup, mint).await;
 
         let other_named_updates = named_updates

--- a/integration_tests/src/common.rs
+++ b/integration_tests/src/common.rs
@@ -206,6 +206,11 @@ impl TestSetup {
             das_api,
         }
     }
+
+    pub async fn clean_up_data_bases(&self) {
+        self.db.clean_db().await.unwrap();
+        self.rocks_db.clean_db().await;
+    }
 }
 
 #[derive(Clone, Copy, Default)]

--- a/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-metadata-updated.snap
+++ b/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-metadata-updated.snap
@@ -1,6 +1,8 @@
 ---
-source: integration_tests/tests/integration_tests/account_update_tests.rs
+source: integration_tests/src/account_update_tests.rs
+assertion_line: 232
 expression: response_new_slot
+snapshot_kind: text
 ---
 {
   "interface": "ProgrammableNFT",
@@ -64,5 +66,16 @@ expression: response_new_slot
   },
   "supply": null,
   "mutable": false,
-  "burnt": false
+  "burnt": false,
+  "lamports": 5616720,
+  "executable": false,
+  "metadata_owner": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
+  "rent_epoch": 18446744073709551615,
+  "token_info": {
+    "supply": 1,
+    "decimals": 0,
+    "token_program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "mint_authority": "BBxbujpLmQgqwu9p1t2S2AZrXuTGBiaUg3M7PUjuBExh",
+    "freeze_authority": "BBxbujpLmQgqwu9p1t2S2AZrXuTGBiaUg3M7PUjuBExh"
+  }
 }

--- a/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-with-all-updates.snap
+++ b/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-with-all-updates.snap
@@ -1,6 +1,8 @@
 ---
-source: integration_tests/tests/integration_tests/account_update_tests.rs
-expression: setup.das_api.get_asset(request.clone()).await.unwrap()
+source: integration_tests/src/account_update_tests.rs
+assertion_line: 266
+expression: "setup.das_api.get_asset(request.clone(), mutexed_tasks.clone()).await.unwrap()"
+snapshot_kind: text
 ---
 {
   "interface": "ProgrammableNFT",
@@ -64,5 +66,16 @@ expression: setup.das_api.get_asset(request.clone()).await.unwrap()
   },
   "supply": null,
   "mutable": false,
-  "burnt": false
+  "burnt": false,
+  "lamports": 5616720,
+  "executable": false,
+  "metadata_owner": "metaqbxxUerdq28cj1RbAWkYQm3ybzjb6a8bt518x1s",
+  "rent_epoch": 18446744073709551615,
+  "token_info": {
+    "supply": 1,
+    "decimals": 0,
+    "token_program": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+    "mint_authority": "BBxbujpLmQgqwu9p1t2S2AZrXuTGBiaUg3M7PUjuBExh",
+    "freeze_authority": "BBxbujpLmQgqwu9p1t2S2AZrXuTGBiaUg3M7PUjuBExh"
+  }
 }

--- a/nft_ingester/src/processors/account_based/token_updates_processor.rs
+++ b/nft_ingester/src/processors/account_based/token_updates_processor.rs
@@ -170,11 +170,6 @@ impl TokenAccountsProcessor {
                     )
                 })
                 .unwrap_or_default(),
-            chain_mutability: Some(Updated::new(
-                mint.slot_updated as u64,
-                Some(UpdateVersion::WriteVersion(mint.write_version)),
-                entities::enums::ChainMutability::Mutable,
-            )),
             onchain_data: metadata_json.map(|metadata_json| {
                 Updated::new(
                     mint.slot_updated as u64,


### PR DESCRIPTION
# What

This PR fixes `test_account_updates` integration test.

# How

It was fixed by adding `clean_db` method and deleting `chain_mutability` value update during Mint account processing. It was always set it to `Mutable` and it was kinda mistake because it affected NFTs where mutability property if defined at Metadata account, not Mint.

All other tests were not affected by these changes.