### PR TITLE
[MTG-1066] using finalized level for signature fetcher

### DIFF
--- a/backfill_rpc/src/rpc.rs
+++ b/backfill_rpc/src/rpc.rs
@@ -83,7 +83,7 @@ impl TransactionsGetter for BackfillRPC {
                                 RpcTransactionConfig {
                                     encoding: Some(UiTransactionEncoding::Base64),
                                     commitment: Some(CommitmentConfig {
-                                        commitment: CommitmentLevel::Confirmed,
+                                        commitment: CommitmentLevel::Finalized,
                                     }),
                                     max_supported_transaction_version: Some(0),
                                 },
@@ -137,7 +137,7 @@ impl BackfillRPC {
                 GetConfirmedSignaturesForAddress2Config {
                     until,
                     commitment: Some(CommitmentConfig {
-                        commitment: CommitmentLevel::Confirmed,
+                        commitment: CommitmentLevel::Finalized,
                     }),
                     before,
                     ..Default::default()

--- a/nft_ingester/src/processors/transaction_processor.rs
+++ b/nft_ingester/src/processors/transaction_processor.rs
@@ -39,7 +39,7 @@ pub async fn run_transaction_processor<TG>(
 
             for tx in txs {
                 match geyser_bubblegum_updates_processor
-                    .process_transaction(tx.tx)
+                    .process_transaction(tx.tx, false)
                     .await
                 {
                     Ok(_) => {

--- a/nft_ingester/src/transaction_ingester.rs
+++ b/nft_ingester/src/transaction_ingester.rs
@@ -14,11 +14,13 @@ impl BackfillTransactionIngester {
         Self { tx_processor }
     }
 }
+
 #[async_trait]
 impl TransactionIngester for BackfillTransactionIngester {
+    // called only from the signatures fetcher at the moment, as it's switched to fetch finalized signatures only it's safe to assume the source is finalized 
     async fn ingest_transaction(&self, tx: BufferedTransaction) -> Result<(), StorageError> {
         self.tx_processor
-            .process_transaction(tx)
+            .process_transaction(tx, true)
             .await
             .map_err(|e| StorageError::Common(e.to_string()))
     }

--- a/rocks-db/src/transaction_client.rs
+++ b/rocks-db/src/transaction_client.rs
@@ -35,11 +35,10 @@ impl Storage {
         &self,
         tx: &TransactionResult,
         with_signatures: bool,
+        is_from_finalized_source: bool,
     ) -> Result<(), StorageError> {
         let mut batch = rocksdb::WriteBatch::default();
-        // this method is currently used only for the geyser plugin handling with confirmed transactions and for signature fetching also with confirmed transactions,
-        // so we can assume that the transactions are from non finalized source
-        self.store_transaction_result_with_batch(&mut batch, tx, with_signatures, false)
+        self.store_transaction_result_with_batch(&mut batch, tx, with_signatures, is_from_finalized_source)
             .await?;
         self.write_batch(batch)
             .await

--- a/usecase/src/signature_fetcher.rs
+++ b/usecase/src/signature_fetcher.rs
@@ -93,6 +93,7 @@ where
         all_signatures.sort_by(|a, b| a.slot.cmp(&b.slot));
         // we need to split the list into batches of BATCH_SIZE
 
+        // todo: use Rust's chunks instead
         let mut batch_start = 0;
         while batch_start < all_signatures.len() {
             let batch_end = std::cmp::min(batch_start + BATCH_SIZE, all_signatures.len());


### PR DESCRIPTION
Before we had `confirmed` data streamed to us from the Geyser plugin, `confirmed` signatures fetched by the relevant worker and `finalized` slots ingested from the slot persister. The signature fetcher confirmation level doesn't seem to add any value, as most transactions are streamed by the Geyser anyway. Switching signature fetcher to finalized level of commitment allows us to define data ingested from signature fetcher as finalized and resolve cNFT forks using signature fetchers.