### PR TITLE
[MTG-1072] improving indexing lag visibility 

### DIFF
--- a/metrics_utils/src/lib.rs
+++ b/metrics_utils/src/lib.rs
@@ -136,7 +136,7 @@ impl MessageProcessMetricsConfig {
     pub fn new() -> Self {
         Self {
             data_read: Family::<MetricLabel, Histogram>::new_with_constructor(|| {
-                Histogram::new(exponential_buckets(1.0, 2.4, 10))
+                Histogram::new(exponential_buckets(50.0, 2.0, 11))
             }),
         }
     }


### PR DESCRIPTION
defining the buckets for the indexing lag with a wider and more appropriate range