### PR TITLE
MTG-1110 Add request time out for DB query

### DIFF
--- a/integrity_verification/src/main.rs
+++ b/integrity_verification/src/main.rs
@@ -82,6 +82,7 @@ async fn main() {
                     &config.database_url.clone().unwrap(),
                     100,
                     500,
+                     Some(120),
                     config.base_dump_path.clone(),
                     metrics.red_metrics,
                 )

--- a/nft_ingester/src/bin/api/main.rs
+++ b/nft_ingester/src/bin/api/main.rs
@@ -66,6 +66,7 @@ pub async fn main() -> Result<(), IngesterError> {
         &args.pg_database_url,
         args.pg_min_db_connections,
         args.pg_max_db_connections,
+        Some(args.pg_max_lifetime_sec),
         None,
         red_metrics.clone(),
     )

--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -128,7 +128,8 @@ pub async fn main() -> Result<(), IngesterError> {
     let index_pg_storage = Arc::new(
         init_index_storage_with_migration(
             &args.pg_database_url,
-            args.pg_max_db_connections.clone(),
+            args.pg_max_db_connections,
+            Some(args.pg_max_lifetime_sec),
             metrics_state.red_metrics.clone(),
             DEFAULT_MIN_POSTGRES_CONNECTIONS,
             PG_MIGRATIONS_PATH,

--- a/nft_ingester/src/bin/migrator/main.rs
+++ b/nft_ingester/src/bin/migrator/main.rs
@@ -38,6 +38,7 @@ pub async fn main() -> Result<(), IngesterError> {
             &args.pg_database_url,
             args.pg_min_db_connections,
             args.pg_max_db_connections,
+            Some(args.pg_max_lifetime_sec),
             None,
             metrics_state.red_metrics.clone(),
         )

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -40,13 +40,13 @@ pub struct IngesterClapArgs {
 
     #[clap(long, default_value = "100")]
     pub pg_max_db_connections: u32,
+    #[clap(long, default_value = "120")]
+    pub pg_max_lifetime_sec: u64,
 
     #[clap(short('r'), long, default_value="{redis_connection_str=\"redis://127.0.0.1:6379/0\"}", value_parser = parse_json_to_dict)]
     pub redis_connection_config: Dict,
-
     #[clap(long, default_value = "20")]
     pub redis_accounts_parsing_workers: u32,
-
     #[clap(long, default_value = "20")]
     pub redis_transactions_parsing_workers: u32,
 
@@ -299,6 +299,8 @@ pub struct MigratorClapArgs {
     pub pg_min_db_connections: u32,
     #[clap(long, default_value = "250")]
     pub pg_max_db_connections: u32,
+    #[clap(long, default_value = "120")]
+    pub pg_max_lifetime_sec: u64,
 
     #[clap(long, help = "Metrics port")]
     pub metrics_port: Option<u16>,
@@ -325,6 +327,8 @@ pub struct ApiClapArgs {
     pub pg_min_db_connections: u32,
     #[clap(long, default_value = "250")]
     pub pg_max_db_connections: u32,
+    #[clap(long, default_value = "120")]
+    pub pg_max_lifetime_sec: u64,
 
     #[clap(
         short('m'),

--- a/nft_ingester/src/init.rs
+++ b/nft_ingester/src/init.rs
@@ -25,6 +25,7 @@ const MALLOC_CONF_ENV: &str = "MALLOC_CONF";
 pub async fn init_index_storage_with_migration(
     url: &str,
     max_pg_connections: u32,
+    max_lifetime_sec: Option<u64>,
     red_metrics: Arc<RequestErrorDurationMetrics>,
     min_pg_connections: u32,
     pg_migrations_path: &str,
@@ -34,6 +35,7 @@ pub async fn init_index_storage_with_migration(
         url,
         min_pg_connections,
         max_pg_connections,
+        max_lifetime_sec,
         base_dump_path,
         red_metrics,
     )

--- a/postgre-client/src/lib.rs
+++ b/postgre-client/src/lib.rs
@@ -57,6 +57,7 @@ impl PgClient {
         url: &str,
         min_connections: u32,
         max_connections: u32,
+        max_lifetime_sec: Option<u64>,
         base_dump_path: Option<PathBuf>,
         metrics: Arc<RequestErrorDurationMetrics>,
     ) -> Result<Self, Error> {
@@ -67,6 +68,7 @@ impl PgClient {
         let pool = PgPoolOptions::new()
             .min_connections(min_connections)
             .max_connections(max_connections)
+            .max_lifetime(max_lifetime_sec.map(Duration::from_secs))
             // 1 hour of a timeout, this is set specifically due to synchronizer needing up to 200 connections to do a full sync load
             .acquire_timeout(Duration::from_secs(3600))
             .connect_with(options)


### PR DESCRIPTION
- Added a request timeout configuration for database queries.

This change allows setting a maximum duration for database queries to prevent long-running operations from blocking the system.