### PR TITLE
[mtg-1162] URI trimming

### DIFF
--- a/entities/src/models.rs
+++ b/entities/src/models.rs
@@ -213,8 +213,8 @@ pub struct ChainDataV1 {
 
 impl ChainDataV1 {
     pub fn sanitize(&mut self) {
-        self.name = self.name.trim().replace('\0', "");
-        self.symbol = self.symbol.trim().replace('\0', "");
+        self.name = self.name.replace('\0', "");
+        self.symbol = self.symbol.replace('\0', "");
     }
 }
 


### PR DESCRIPTION
Stop trimming whitespace in the name and metadata of assets to prevent invalid indexing.