### PR TITLE
[mtg-808] optimize select for show fungible display option

### DIFF
--- a/postgre-client/tests/asset_index_client_test.rs
+++ b/postgre-client/tests/asset_index_client_test.rs
@@ -8,6 +8,7 @@ mod tests {
     use postgre_client::storage_traits::AssetIndexStorage;
     use rand::Rng;
     use setup::pg::*;
+    use solana_sdk::pubkey::Pubkey;
     use testcontainers::clients::Cli;
 
     #[tokio::test]
@@ -86,12 +87,12 @@ mod tests {
         // every asset_index will have 3 creators
         for asset_index in asset_indexes.iter_mut() {
             asset_index.creators.push(Creator {
-                creator: generate_random_pubkey(),
+                creator: Pubkey::new_unique(),
                 creator_verified: rand::thread_rng().gen_bool(0.5),
                 creator_share: 30,
             });
             asset_index.creators.push(Creator {
-                creator: generate_random_pubkey(),
+                creator: Pubkey::new_unique(),
                 creator_verified: rand::thread_rng().gen_bool(0.5),
                 creator_share: 30,
             });
@@ -119,7 +120,7 @@ mod tests {
             .map(|asset_index| {
                 let mut ai = asset_index.clone();
                 ai.creators.pop();
-                ai.creators[1].creator = generate_random_pubkey();
+                ai.creators[1].creator = Pubkey::new_unique();
                 ai.creators[0].creator_verified = !ai.creators[0].creator_verified;
                 ai
             })

--- a/rocks-db/src/column.rs
+++ b/rocks-db/src/column.rs
@@ -236,10 +236,8 @@ where
             )
             .into_iter()
             .map(|res| {
-                res.map_err(StorageError::from).and_then(|opt| {
-                    opt.map(|pinned| C::decode(pinned.as_ref()).map_err(StorageError::from))
-                        .transpose()
-                })
+                res.map_err(StorageError::from)
+                    .and_then(|opt| opt.map(|pinned| C::decode(pinned.as_ref())).transpose())
             })
             .collect()
     }

--- a/rocks-db/src/columns/asset.rs
+++ b/rocks-db/src/columns/asset.rs
@@ -1958,7 +1958,7 @@ pub fn merge_complete_details_fb_simple_raw<'a>(
             }
             // Merge authority
             if let Some(new_authority) = new_val.authority() {
-                if authority.map_or(true, |current_authority| {
+                if authority.is_none_or(|current_authority| {
                     new_authority.compare(&current_authority) == Ordering::Greater
                 }) {
                     authority = Some(new_authority);

--- a/rocks-db/src/sequence_consistent.rs
+++ b/rocks-db/src/sequence_consistent.rs
@@ -30,7 +30,7 @@ impl SequenceConsistentManager for Storage {
         let result = if gap_found {
             self.trees_gaps.put_async(tree, TreesGaps {}).await
         } else {
-            self.trees_gaps.delete(tree).map_err(Into::into)
+            self.trees_gaps.delete(tree)
         };
         if let Err(e) = result {
             error!("{} tree gap: {}", if gap_found { "Put" } else { "Delete" }, e);

--- a/tests/setup/src/pg.rs
+++ b/tests/setup/src/pg.rs
@@ -2,7 +2,7 @@ use std::{collections::BTreeMap, path::PathBuf, str::FromStr, sync::Arc};
 
 use entities::{
     enums::*,
-    models::{AssetIndex, Creator, UrlWithStatus},
+    models::{AssetIndex, Creator, FungibleAssetIndex, UrlWithStatus},
 };
 use metrics_utils::red::RequestErrorDurationMetrics;
 use postgre_client::{storage_traits::AssetIndexStorage, PgClient};
@@ -187,24 +187,20 @@ pub fn generate_random_vec(n: usize) -> Vec<u8> {
     random_vector
 }
 
-pub fn generate_random_pubkey() -> Pubkey {
-    Pubkey::new_unique()
-}
-
 pub fn generate_asset_index_records(n: usize) -> Vec<AssetIndex> {
     let mut asset_indexes = Vec::new();
     for i in 0..n {
         let asset_index = AssetIndex {
-            pubkey: generate_random_pubkey(),
+            pubkey: Pubkey::new_unique(),
             specification_version: SpecificationVersions::V1,
             specification_asset_class: SpecificationAssetClass::Nft,
             royalty_target_type: RoyaltyTargetType::Creators,
             royalty_amount: 1,
             slot_created: (n - i) as i64,
-            owner: Some(generate_random_pubkey()),
-            delegate: Some(generate_random_pubkey()),
-            authority: Some(generate_random_pubkey()),
-            collection: Some(generate_random_pubkey()),
+            owner: Some(Pubkey::new_unique()),
+            delegate: Some(Pubkey::new_unique()),
+            authority: Some(Pubkey::new_unique()),
+            collection: Some(Pubkey::new_unique()),
             is_collection_verified: Some(rand::thread_rng().gen_bool(0.5)),
             is_burnt: false,
             is_compressible: false,
@@ -218,13 +214,28 @@ pub fn generate_asset_index_records(n: usize) -> Vec<AssetIndex> {
             update_authority: None,
             slot_updated: (n + 10 + i) as i64,
             creators: vec![Creator {
-                creator: generate_random_pubkey(),
+                creator: Pubkey::new_unique(),
                 creator_verified: rand::thread_rng().gen_bool(0.5),
                 creator_share: 100,
             }],
             owner_type: Some(OwnerType::Single),
             fungible_asset_mint: None,
             fungible_asset_balance: None,
+        };
+        asset_indexes.push(asset_index);
+    }
+    asset_indexes
+}
+
+pub fn generate_fungible_asset_index_records(n: usize) -> Vec<FungibleAssetIndex> {
+    let mut asset_indexes = Vec::new();
+    for i in 0..n {
+        let asset_index = FungibleAssetIndex {
+            pubkey: Pubkey::new_unique(),
+            owner: Some(Pubkey::new_unique()),
+            slot_updated: (n + 10 + i) as i64,
+            fungible_asset_mint: None,
+            fungible_asset_balance: Some(1),
         };
         asset_indexes.push(asset_index);
     }


### PR DESCRIPTION
The PR optimizes the search request via dropping OR condition if a search for all token types is requested. OR condition in such case provokes seq scan through the table. 
To avoid this, UNION between two selects is used instead.