### PR TITLE
MTG 1235 Extend range of interfaces for supply object display

### DIFF
--- a/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-metadata-updated.snap
+++ b/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-metadata-updated.snap
@@ -64,7 +64,11 @@ snapshot_kind: text
     "ownership_model": "single",
     "owner": "BzbdvwEkQKeghTY53aZxTYjUienhdbkNVkgrLV6cErke"
   },
-  "supply": null,
+  "supply": {
+    "print_max_supply": 0,
+    "print_current_supply": 0,
+    "edition_nonce": 253
+  },
   "mutable": false,
   "burnt": false,
   "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-token-updated.snap
+++ b/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-token-updated.snap
@@ -64,7 +64,11 @@ snapshot_kind: text
     "ownership_model": "single",
     "owner": "1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM"
   },
-  "supply": null,
+  "supply": {
+    "print_max_supply": 0,
+    "print_current_supply": 0,
+    "edition_nonce": 253
+  },
   "mutable": true,
   "burnt": false,
   "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-with-all-updates.snap
+++ b/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates-with-all-updates.snap
@@ -64,7 +64,11 @@ snapshot_kind: text
     "ownership_model": "single",
     "owner": "1111111QLbz7JHiBTspS962RLKV8GndWFwiEaqKM"
   },
-  "supply": null,
+  "supply": {
+    "print_max_supply": 0,
+    "print_current_supply": 0,
+    "edition_nonce": 253
+  },
   "mutable": false,
   "burnt": false,
   "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates.snap
+++ b/integration_tests/src/snapshots/integration_tests__account_update_tests__account_updates.snap
@@ -64,7 +64,11 @@ snapshot_kind: text
     "ownership_model": "single",
     "owner": "BzbdvwEkQKeghTY53aZxTYjUienhdbkNVkgrLV6cErke"
   },
-  "supply": null,
+  "supply": {
+    "print_max_supply": 0,
+    "print_current_supply": 0,
+    "edition_nonce": 253
+  },
   "mutable": true,
   "burnt": false,
   "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__general_scenario_tests__asset_parsing.snap
+++ b/integration_tests/src/snapshots/integration_tests__general_scenario_tests__asset_parsing.snap
@@ -64,7 +64,11 @@ snapshot_kind: text
     "ownership_model": "single",
     "owner": "BzbdvwEkQKeghTY53aZxTYjUienhdbkNVkgrLV6cErke"
   },
-  "supply": null,
+  "supply": {
+    "print_max_supply": 0,
+    "print_current_supply": 0,
+    "edition_nonce": 253
+  },
   "mutable": true,
   "burnt": false,
   "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset.snap
+++ b/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset.snap
@@ -70,7 +70,11 @@ snapshot_kind: text
     "ownership_model": "single",
     "owner": "A59E2tNJEqNN9TDnzgGnmLmnTsdRDoPocGx3n1w2dqZw"
   },
-  "supply": null,
+  "supply": {
+    "print_max_supply": 0,
+    "print_current_supply": 0,
+    "edition_nonce": 255
+  },
   "mutable": true,
   "burnt": false,
   "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-2-and-a-missing-1.snap
+++ b/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-2-and-a-missing-1.snap
@@ -71,7 +71,11 @@ snapshot_kind: text
       "ownership_model": "single",
       "owner": "9PacVenjPyQYiWBha89UYRM1nn6mf9bGY7vi32zY6DLn"
     },
-    "supply": null,
+    "supply": {
+      "print_max_supply": 0,
+      "print_current_supply": 0,
+      "edition_nonce": 255
+    },
     "mutable": true,
     "burnt": false,
     "lamports": 5616720,
@@ -153,7 +157,11 @@ snapshot_kind: text
       "ownership_model": "single",
       "owner": "3H3d3hfpZVVdVwuFAxDtDSFN2AdR7kwiDA3ynbnbkhc9"
     },
-    "supply": null,
+    "supply": {
+      "print_max_supply": 0,
+      "print_current_supply": 0,
+      "edition_nonce": 255
+    },
     "mutable": true,
     "burnt": false,
     "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-only-2-different-2.snap
+++ b/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-only-2-different-2.snap
@@ -71,7 +71,11 @@ snapshot_kind: text
       "ownership_model": "single",
       "owner": "9PacVenjPyQYiWBha89UYRM1nn6mf9bGY7vi32zY6DLn"
     },
-    "supply": null,
+    "supply": {
+      "print_max_supply": 0,
+      "print_current_supply": 0,
+      "edition_nonce": 255
+    },
     "mutable": true,
     "burnt": false,
     "lamports": 5616720,
@@ -152,7 +156,11 @@ snapshot_kind: text
       "ownership_model": "single",
       "owner": "3H3d3hfpZVVdVwuFAxDtDSFN2AdR7kwiDA3ynbnbkhc9"
     },
-    "supply": null,
+    "supply": {
+      "print_max_supply": 0,
+      "print_current_supply": 0,
+      "edition_nonce": 255
+    },
     "mutable": true,
     "burnt": false,
     "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-only-2.snap
+++ b/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_batch-only-2.snap
@@ -71,7 +71,11 @@ snapshot_kind: text
       "ownership_model": "single",
       "owner": "BaBQKh34KrqZzd4ifSHQYMf86HiBGASN6TWUi1ZwfyKv"
     },
-    "supply": null,
+    "supply": {
+      "print_max_supply": 0,
+      "print_current_supply": 0,
+      "edition_nonce": 252
+    },
     "mutable": true,
     "burnt": false,
     "lamports": 5616720,
@@ -152,7 +156,11 @@ snapshot_kind: text
       "ownership_model": "single",
       "owner": "9PacVenjPyQYiWBha89UYRM1nn6mf9bGY7vi32zY6DLn"
     },
-    "supply": null,
+    "supply": {
+      "print_max_supply": 0,
+      "print_current_supply": 0,
+      "edition_nonce": 255
+    },
     "mutable": true,
     "burnt": false,
     "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_by_group.snap
+++ b/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_get_asset_by_group.snap
@@ -80,7 +80,11 @@ snapshot_kind: text
         "ownership_model": "single",
         "owner": "9qUcfdADyrrTSetFjNjF9Ro7LKAqzJkzZV6WKLHfv5MU"
       },
-      "supply": null,
+      "supply": {
+        "print_max_supply": 0,
+        "print_current_supply": 0,
+        "edition_nonce": 254
+      },
       "mutable": true,
       "burnt": false,
       "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_search_assets.snap
+++ b/integration_tests/src/snapshots/integration_tests__regular_nft_tests__reg_search_assets.snap
@@ -75,7 +75,11 @@ snapshot_kind: text
         "ownership_model": "single",
         "owner": "6Cr66AabRYymhZgYQSfTCo6FVpH18wXrMZswAbcErpyX"
       },
-      "supply": null,
+      "supply": {
+        "print_max_supply": 0,
+        "print_current_supply": 0,
+        "edition_nonce": 255
+      },
       "mutable": true,
       "burnt": false,
       "lamports": 5616720,

--- a/integration_tests/src/snapshots/integration_tests__regular_nft_tests__regular_nft_collection.snap
+++ b/integration_tests/src/snapshots/integration_tests__regular_nft_tests__regular_nft_collection.snap
@@ -59,7 +59,11 @@ snapshot_kind: text
     "ownership_model": "single",
     "owner": "2RtGg6fsFiiF1EQzHqbd66AhW7R5bWeQGpTbv2UMkCdW"
   },
-  "supply": null,
+  "supply": {
+    "print_max_supply": 0,
+    "print_current_supply": 0,
+    "edition_nonce": 253
+  },
   "mutable": true,
   "burnt": false,
   "lamports": 5616720,

--- a/nft_ingester/src/api/dapi/rpc_asset_convertors.rs
+++ b/nft_ingester/src/api/dapi/rpc_asset_convertors.rs
@@ -366,7 +366,11 @@ pub fn asset_to_rpc(
         _ => None,
     };
     let supply = match interface {
-        Interface::V1NFT => {
+        Interface::V1NFT
+        | Interface::LegacyNft
+        | Interface::Nft
+        | Interface::ProgrammableNFT
+        | Interface::Custom => {
             if let Some(edition_info) = &full_asset.edition_data {
                 Some(Supply {
                     edition_nonce,


### PR DESCRIPTION
# What

This PR extends range of interfaces for which we display `supply` object on API response. Basicaly there were added more interfaces which may have edition information which could be put into `supply` object.

From the changes in snapshots of integration tests we can see what is changing for the user.