### PR TITLE
[MTG-1258] an option to turn off the json re-download, enabled by default

### DIFF
--- a/interface/src/json.rs
+++ b/interface/src/json.rs
@@ -14,6 +14,7 @@ pub trait JsonDownloader {
         &self,
         url: String,
     ) -> Result<JsonDownloadResult, crate::error::JsonDownloaderError>;
+    fn skips_refreshes(&self) -> bool;
 }
 
 #[automock]

--- a/interface/src/json.rs
+++ b/interface/src/json.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use async_trait::async_trait;
 use mockall::automock;
 
@@ -13,6 +15,7 @@ pub trait JsonDownloader {
     async fn download_file(
         &self,
         url: String,
+        timeout: Duration,
     ) -> Result<JsonDownloadResult, crate::error::JsonDownloaderError>;
     fn skips_refreshes(&self) -> bool;
 }

--- a/interface/src/json.rs
+++ b/interface/src/json.rs
@@ -17,7 +17,7 @@ pub trait JsonDownloader {
         url: String,
         timeout: Duration,
     ) -> Result<JsonDownloadResult, crate::error::JsonDownloaderError>;
-    fn skips_refreshes(&self) -> bool;
+    fn skip_refresh(&self) -> bool;
 }
 
 #[automock]

--- a/nft_ingester/src/api/dapi/asset.rs
+++ b/nft_ingester/src/api/dapi/asset.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, string::ToString, sync::Arc};
+use std::{collections::HashMap, string::ToString, sync::Arc, time::Duration};
 
 use entities::{
     api_req_params::{AssetSortDirection, Options},
@@ -33,6 +33,7 @@ use crate::api::dapi::rpc_asset_models::FullAsset;
 
 pub const COLLECTION_GROUP_KEY: &str = "collection";
 pub const METADATA_CACHE_TTL: i64 = 86400; // 1 day
+pub const CLIENT_TIMEOUT: Duration = Duration::from_secs(3);
 
 fn convert_rocks_asset_model(
     asset_pubkey: &Pubkey,
@@ -268,7 +269,8 @@ pub async fn get_by_ids<
                     let json_downloader = json_downloader.clone();
 
                     async move {
-                        let response = json_downloader.download_file(url.clone()).await;
+                        let response =
+                            json_downloader.download_file(url.clone(), CLIENT_TIMEOUT).await;
                         (url, response)
                     }
                 })

--- a/nft_ingester/src/api/dapi/asset.rs
+++ b/nft_ingester/src/api/dapi/asset.rs
@@ -230,6 +230,7 @@ pub async fn get_by_ids<
                     let curr_time = chrono::Utc::now().timestamp();
                     if offchain_data.storage_mutability.is_mutable()
                         && curr_time > offchain_data.last_read_at + METADATA_CACHE_TTL
+                        && !json_downloader.skips_refreshes()
                     {
                         download_needed = true;
                     }

--- a/nft_ingester/src/api/dapi/asset.rs
+++ b/nft_ingester/src/api/dapi/asset.rs
@@ -231,7 +231,7 @@ pub async fn get_by_ids<
                     let curr_time = chrono::Utc::now().timestamp();
                     if offchain_data.storage_mutability.is_mutable()
                         && curr_time > offchain_data.last_read_at + METADATA_CACHE_TTL
-                        && !json_downloader.skips_refreshes()
+                        && !json_downloader.skip_refresh()
                     {
                         download_needed = true;
                     }

--- a/nft_ingester/src/bin/api/main.rs
+++ b/nft_ingester/src/bin/api/main.rs
@@ -102,6 +102,7 @@ pub async fn main() -> Result<(), IngesterError> {
                         json_downloader_metrics.clone(),
                         red_metrics.clone(),
                         args.parallel_json_downloaders,
+                        args.api_skip_inline_json_refresh.unwrap_or_default(),
                     )
                     .await,
                 ))

--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -281,6 +281,7 @@ pub async fn main() -> Result<(), IngesterError> {
             metrics_state.json_downloader_metrics.clone(),
             metrics_state.red_metrics.clone(),
             args.parallel_json_downloaders,
+            args.api_skip_inline_json_refresh.unwrap_or_default(),
         )
         .await,
     );

--- a/nft_ingester/src/bin/slot_checker/main.rs
+++ b/nft_ingester/src/bin/slot_checker/main.rs
@@ -15,7 +15,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use interface::slots_dumper::SlotsDumper;
 use metrics_utils::MetricState;
 use rocks_db::{
-    column::TypedColumn, columns::offchain_data::OffChainData, migrator::MigrationVersions, Storage,
+    column::TypedColumn, columns::offchain_data::{OffChainData, OffChainDataDeprecated}, migrator::MigrationVersions, Storage,
 };
 use tokio::{
     signal,
@@ -113,7 +113,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let db = Arc::new(
         Storage::open_readonly_with_cfs(
             &args.target_db_path,
-            vec![RawBlock::NAME, MigrationVersions::NAME, OffChainData::NAME],
+            vec![RawBlock::NAME, MigrationVersions::NAME, OffChainDataDeprecated::NAME],
             Arc::new(tokio::sync::Mutex::new(tokio::task::JoinSet::new())),
             metrics_state.red_metrics,
         )

--- a/nft_ingester/src/bin/slot_checker/main.rs
+++ b/nft_ingester/src/bin/slot_checker/main.rs
@@ -15,7 +15,8 @@ use indicatif::{ProgressBar, ProgressStyle};
 use interface::slots_dumper::SlotsDumper;
 use metrics_utils::MetricState;
 use rocks_db::{
-    column::TypedColumn, columns::offchain_data::{OffChainData, OffChainDataDeprecated}, migrator::MigrationVersions, Storage,
+    column::TypedColumn, columns::offchain_data::OffChainDataDeprecated,
+    migrator::MigrationVersions, Storage,
 };
 use tokio::{
     signal,

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -71,6 +71,14 @@ pub struct IngesterClapArgs {
     pub parallel_json_downloaders: i32,
 
     #[clap(
+        long,
+        env,
+        default_value = "true",
+        help = "Skip inline json refreshes if the metadata may be stale"
+    )]
+    pub api_skip_inline_json_refresh: Option<bool>,
+
+    #[clap(
         long("run-api"),
         default_value = "true",
         env = "RUN_API",
@@ -506,7 +514,13 @@ pub struct ApiClapArgs {
     pub json_middleware_config: Option<JsonMiddlewareConfig>,
     #[clap(long, env, default_value = "100")]
     pub parallel_json_downloaders: i32,
-
+    #[clap(
+        long,
+        env,
+        default_value = "true",
+        help = "Skip inline json refreshes if the metadata may be stale"
+    )]
+    pub api_skip_inline_json_refresh: Option<bool>,
     #[clap(long, env, default_value = "info", help = "info|debug")]
     pub log_level: String,
 }

--- a/nft_ingester/src/json_worker.rs
+++ b/nft_ingester/src/json_worker.rs
@@ -347,7 +347,7 @@ impl JsonDownloader for JsonWorker {
         }
     }
 
-    fn skips_refreshes(&self) -> bool {
+    fn skip_refresh(&self) -> bool {
         self.should_skip_refreshes
     }
 }

--- a/nft_ingester/src/json_worker.rs
+++ b/nft_ingester/src/json_worker.rs
@@ -33,6 +33,7 @@ pub struct JsonWorker {
     pub db_client: Arc<PgClient>,
     pub rocks_db: Arc<Storage>,
     pub num_of_parallel_workers: i32,
+    pub should_skip_refreshes: bool,
     pub metrics: Arc<JsonDownloaderMetricsConfig>,
     pub red_metrics: Arc<RequestErrorDurationMetrics>,
 }
@@ -44,10 +45,12 @@ impl JsonWorker {
         metrics: Arc<JsonDownloaderMetricsConfig>,
         red_metrics: Arc<RequestErrorDurationMetrics>,
         parallel_json_downloaders: i32,
+        should_skip_refreshes: bool,
     ) -> Self {
         Self {
             db_client,
             num_of_parallel_workers: parallel_json_downloaders,
+            should_skip_refreshes,
             metrics,
             red_metrics,
             rocks_db,
@@ -340,6 +343,10 @@ impl JsonDownloader for JsonWorker {
                 Err(JsonDownloaderError::ErrorDownloading(e.to_string()))
             },
         }
+    }
+
+    fn skips_refreshes(&self) -> bool {
+        self.should_skip_refreshes
     }
 }
 

--- a/nft_ingester/tests/api_tests.rs
+++ b/nft_ingester/tests/api_tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 #[cfg(feature = "integration_tests")]
 mod tests {
-    use std::{collections::HashMap, str::FromStr, sync::Arc};
+    use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
 
     use base64::{engine::general_purpose, Engine};
     use blockbuster::{
@@ -2308,11 +2308,13 @@ mod tests {
         "#;
 
         let mut mock_middleware = MockJsonDownloader::new();
-        mock_middleware.expect_download_file().with(predicate::eq(url)).times(1).returning(
-            move |_| {
+        mock_middleware
+            .expect_download_file()
+            .with(predicate::eq(url), predicate::eq(Duration::from_secs(3)))
+            .times(1)
+            .returning(move |_, _| {
                 Ok(interface::json::JsonDownloadResult::JsonContent(offchain_data.to_string()))
-            },
-        );
+            });
 
         let api = nft_ingester::api::api_impl::DasApi::<
             MaybeProofChecker,


### PR DESCRIPTION
As a short-term solution for longer requests we disable the cache invalidation alongside the request.
Also we separate the inline json download timeout from the main workers timeout, letting workers wait for 30 seconds for the response, while the inline download is restricted to 3 seconds.