### PR TITLE
feat(ingester): add metrics for `RedisReceiver`

### DIFF
--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -192,8 +192,13 @@ pub async fn main() -> Result<(), IngesterError> {
             },
         };
         let redis_receiver = Arc::new(
-            RedisReceiver::new(personal_message_config, ConsumptionType::All, ack_channel.clone())
-                .await?,
+            RedisReceiver::new(
+                personal_message_config,
+                ConsumptionType::All,
+                ack_channel.clone(),
+                metrics_state.redis_receiver_metrics.clone(),
+            )
+            .await?,
         );
 
         run_accounts_processor(
@@ -236,6 +241,7 @@ pub async fn main() -> Result<(), IngesterError> {
                 personal_message_config.clone(),
                 ConsumptionType::All,
                 ack_channel.clone(),
+                metrics_state.redis_receiver_metrics.clone(),
             )
             .await?,
         );

--- a/nft_ingester/src/config.rs
+++ b/nft_ingester/src/config.rs
@@ -580,7 +580,7 @@ impl BigTableConfig {
 
 pub fn init_logger(log_level: &str) {
     let t = tracing_subscriber::fmt().with_env_filter(log_level);
-    t.event_format(fmt::format::json()).init();
+    t.event_format(fmt::format::json().with_line_number(true).with_file(true)).init();
 }
 
 #[cfg(test)]

--- a/nft_ingester/src/message_parser.rs
+++ b/nft_ingester/src/message_parser.rs
@@ -1,4 +1,4 @@
-use std::{fmt::Debug, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 
 use blockbuster::{
     error::BlockbusterError,
@@ -19,7 +19,7 @@ use entities::{
 use flatbuffers::FlatBufferBuilder;
 use itertools::Itertools;
 use solana_program::{program_pack::Pack, pubkey::Pubkey};
-use tracing::log::{debug, warn};
+use tracing::{debug, warn};
 use utils::flatbuffer::account_data_generated::account_data::root_as_account_data;
 
 use crate::{
@@ -150,7 +150,7 @@ impl MessageParser {
                 };
             },
             Err(e) => {
-                account_parsing_error(e, account_info);
+                warn!(error = %e, pubkey = %account_info.pubkey, "Error while parsing account: {:?} {:?}", e, account_info);
             },
         }
 
@@ -249,7 +249,7 @@ impl MessageParser {
                 };
             },
             Err(e) => {
-                account_parsing_error(e, account_update);
+                warn!(error = %e, pubkey = %account_update.pubkey, "Error while parsing account: {:?} {:?}", e, account_update);
             },
         }
 
@@ -349,7 +349,9 @@ impl MessageParser {
             Err(e) => match e {
                 BlockbusterError::AccountTypeNotImplemented
                 | BlockbusterError::UninitializedAccount => {},
-                _ => account_parsing_error(e, account_info),
+                _ => {
+                    warn!(error = %e, pubkey = %account_info.pubkey, "Error while parsing account: {:?} {:?}", e, account_info)
+                },
             },
         }
 
@@ -372,7 +374,7 @@ impl MessageParser {
                 };
             },
             Err(e) => {
-                account_parsing_error(e, account_info);
+                warn!(error = %e, pubkey = %account_info.pubkey, "Error while parsing account: {:?} {:?}", e, account_info)
             },
         }
 
@@ -409,7 +411,7 @@ impl MessageParser {
                 ParsedInscription::UnhandledAccount => {},
             },
             Err(e) => {
-                account_parsing_error(e, account_info);
+                warn!(error = %e, pubkey = %account_info.pubkey, "Error while parsing account: {:?} {:?}", e, account_info)
             },
         }
 
@@ -507,8 +509,4 @@ fn map_account_info_fb_bytes(
     builder.finish(account_info_wip, None);
 
     Ok(builder.finished_data().to_owned())
-}
-
-fn account_parsing_error(err: impl Debug, account_info: &plerkle::AccountInfo) {
-    warn!("Error while parsing account: {:?} {}", err, account_info.pubkey);
 }


### PR DESCRIPTION
NOTE! This PR also adds filename and line number printing to all logs emitted using `tracing::error!/info!/debug!/trace!`. This is in line with the configuration of the `log` crate we use, but nevertheless important to mention here.

The rest of the PR adds metrics describing the lifecycle of `RedisReceiver`.