### PR TITLE
[MTG-1166] Changing owner index to speed up owner based requests

### DIFF
--- a/migrations/11_owner_index.sql
+++ b/migrations/11_owner_index.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS assets_v3_owner;
+CREATE INDEX IF NOT EXISTS idx_assets_v3_owner_pubkey ON assets_v3 (ast_owner, ast_pubkey DESC);


### PR DESCRIPTION
migration to add an appropriate index for queries with owner as those are always sorted by smth 
Previously the index used for getAssetByOwner was planned as
```
Limit  (cost=0.70..2570578.36 rows=1000 width=49) (actual time=72.449..2881.472 rows=1000 loops=1)"
"  ->  Index Scan Backward using assets_pkey on assets_v3  (cost=0.70..3148777688.88 rows=1224930 width=49) (actual time=0.807..2809.575 rows=1000 loops=1)"
"        Filter: ((ast_supply > 0) AND (ast_owner = '\x000be3e1eba17a473f89b0f7e8e24940f20aeb8ebca71a88fde95d4b83b71a09'::bytea))"
"        Rows Removed by Filter: 602490"
"Planning Time: 0.936 ms"
"JIT:"
"  Functions: 6"
"  Options: Inlining true, Optimization true, Expressions true, Deforming true"
"  Timing: Generation 1.355 ms, Inlining 11.620 ms, Optimization 39.588 ms, Emission 20.435 ms, Total 72.997 ms"
"Execution Time: 2883.036 ms"
```
After adding the index
```
"Limit  (cost=0.70..4090.63 rows=1000 width=49) (actual time=0.406..36.051 rows=1000 loops=1)"
"  ->  Index Scan using idx_assets_v3_owner_pubkey on assets_v3  (cost=0.70..5017909.19 rows=1226892 width=49) (actual time=0.402..35.941 rows=1000 loops=1)"
"        Index Cond: (ast_owner = '\x000be3e1eba17a473f89b0f7e8e24940f20aeb8ebca71a88fde95d4b83b71a09'::bytea)"
"        Filter: (ast_supply > 0)"
"Planning Time: 0.693 ms"
"Execution Time: 36.151 ms"
```

The main change here is the `Rows Removed by Filter: 602490` - so essentially the query was scanning 602k rows to find 1k