### PR TITLE
MTG 1289 Fix redis_total_accounts_parsed metric

### DIFF
--- a/nft_ingester/src/redis_receiver.rs
+++ b/nft_ingester/src/redis_receiver.rs
@@ -114,7 +114,7 @@ impl UnprocessedAccountsGetter for RedisReceiver {
                 },
             }
         }
-        self.metrics.inc_accounts_parsed_by(result.len() as u64);
+        self.metrics.inc_accounts_parsed_by((result.len() + unknown_account_types_ids.len()) as u64);
 
         UnprocessedAccountsGetter::ack(self, unknown_account_types_ids);
         Ok(result)

--- a/nft_ingester/src/redis_receiver.rs
+++ b/nft_ingester/src/redis_receiver.rs
@@ -114,7 +114,8 @@ impl UnprocessedAccountsGetter for RedisReceiver {
                 },
             }
         }
-        self.metrics.inc_accounts_parsed_by((result.len() + unknown_account_types_ids.len()) as u64);
+        self.metrics
+            .inc_accounts_parsed_by((result.len() + unknown_account_types_ids.len()) as u64);
 
         UnprocessedAccountsGetter::ack(self, unknown_account_types_ids);
         Ok(result)


### PR DESCRIPTION
# What
This PR fixes counting redis_total_accounts_parsed metric. The issue is that value is incremented by `result.len()` but if `self.message_parser.parse_account(item.data, false)` returns empty vector we don't write anything to the `result` vec, but message was processed by fact. Parse_account method may return empty vector if it received account with program owner which we don't support. So as a result of this issue we can see not very informative metric on Grafana - `Unparsed Transactions & Accounts`, which looks like ingester cannot parse all the data, but it's wrong, we see it only because values in metric were not calculated correctly. It didn't happen before because previous Solana snapshot ETL was using Geyser plugin  which has accounts filter inside and it sent only accounts which Aura supports. But with PR https://github.com/metaplex-foundation/digital-asset-validator-plugin/pull/88 now ETL sends all the accounts from the snapshot.