### PR TITLE
ci: enable CI for develop branch PRs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust CI
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
   Enable CI for develop branch PRs
   
   - Update GitHub Actions workflow to run on PRs targeting develop branch
   - Maintain same CI checks for both main and develop branches
   - Ensure code quality standards are enforced before merging to develop