### PR TITLE
[MTG-1301] Fix Docker workflow permissions

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,11 @@ on:
     branches: [develop]
     tags: ["v*"]
 
+# Add permissions block for GitHub Container Registry access
+permissions:
+  contents: read
+  packages: write
+
 env:
   PUSH_CONDITION: ${{ github.event_name == 'push' || (github.event_name == 'workflow_dispatch' && contains(fromJSON('["refs/head/main", "refs/head/develop"]'), github.event.workflow_dispatch.ref)) }}
 


### PR DESCRIPTION
This PR adds required permissions for GitHub Container Registry access in the Docker workflow.

## Changes
- Add permissions block to docker.yml workflow
- Grant read access to repository contents
- Grant write access to packages for GitHub Container Registry
 
This should fix the 'unauthorized: access token has insufficient scopes' error during Docker image pushes.

Closes #MTG-1301