### PR TITLE
feat(api): rework payload parsing

### DIFF
--- a/entities/src/api_req_params.rs
+++ b/entities/src/api_req_params.rs
@@ -51,14 +51,10 @@ pub enum AssetSortDirection {
     Desc,
 }
 
-const fn default_show_unverified_collections() -> bool {
-    true
-}
-
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct Options {
-    #[serde(default = "default_show_unverified_collections")]
+    #[serde(default)]
     pub show_unverified_collections: bool,
     #[serde(default)]
     pub show_collection_metadata: bool,
@@ -73,7 +69,7 @@ pub struct Options {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct SearchAssetsOptions {
-    #[serde(default = "default_show_unverified_collections")]
+    #[serde(default)]
     pub show_unverified_collections: bool,
     #[serde(default)]
     pub show_grand_total: bool,
@@ -90,7 +86,7 @@ pub struct SearchAssetsOptions {
 #[derive(Serialize, Deserialize, Clone, Debug, Eq, PartialEq, JsonSchema, Default)]
 #[serde(deny_unknown_fields, rename_all = "camelCase")]
 pub struct GetByMethodsOptions {
-    #[serde(default = "default_show_unverified_collections")]
+    #[serde(default)]
     pub show_unverified_collections: bool,
     #[serde(default)]
     pub show_grand_total: bool,
@@ -416,10 +412,7 @@ impl From<SearchAssetsV0> for SearchAssets {
             json_uri: value.json_uri,
             cursor: None,
             name: None,
-            options: SearchAssetsOptions {
-                show_unverified_collections: true,
-                ..Default::default()
-            },
+            options: Default::default(),
         }
     }
 }
@@ -432,15 +425,7 @@ pub struct GetAssetV0 {
 
 impl From<GetAssetV0> for GetAsset {
     fn from(value: GetAssetV0) -> Self {
-        Self {
-            id: value.id,
-            options: Options {
-                show_unverified_collections: true,
-                show_collection_metadata: false,
-                show_inscription: false,
-                show_fungible: false,
-            },
-        }
+        Self { id: value.id, options: Default::default() }
     }
 }
 
@@ -452,15 +437,7 @@ pub struct GetAssetBatchV0 {
 
 impl From<GetAssetBatchV0> for GetAssetBatch {
     fn from(value: GetAssetBatchV0) -> Self {
-        Self {
-            ids: value.ids,
-            options: Options {
-                show_unverified_collections: true,
-                show_collection_metadata: false,
-                show_inscription: false,
-                show_fungible: false,
-            },
-        }
+        Self { ids: value.ids, options: Default::default() }
     }
 }
 
@@ -485,10 +462,7 @@ impl From<GetAssetsByAuthorityV0> for GetAssetsByAuthority {
             before: value.before,
             after: value.after,
             cursor: None,
-            options: GetByMethodsOptions {
-                show_unverified_collections: true,
-                ..Default::default()
-            },
+            options: Default::default(),
         }
     }
 }
@@ -516,10 +490,7 @@ impl From<GetAssetsByCreatorV0> for GetAssetsByCreator {
             before: value.before,
             after: value.after,
             cursor: None,
-            options: GetByMethodsOptions {
-                show_unverified_collections: true,
-                ..Default::default()
-            },
+            options: Default::default(),
         }
     }
 }
@@ -545,10 +516,7 @@ impl From<GetAssetsByOwnerV0> for GetAssetsByOwner {
             before: value.before,
             after: value.after,
             cursor: None,
-            options: GetByMethodsOptions {
-                show_unverified_collections: true,
-                ..Default::default()
-            },
+            options: Default::default(),
         }
     }
 }
@@ -576,10 +544,7 @@ impl From<GetAssetsByGroupV0> for GetAssetsByGroup {
             before: value.before,
             after: value.after,
             cursor: None,
-            options: GetByMethodsOptions {
-                show_unverified_collections: true,
-                ..Default::default()
-            },
+            options: Default::default(),
         }
     }
 }

--- a/entities/src/api_req_params.rs
+++ b/entities/src/api_req_params.rs
@@ -576,7 +576,10 @@ impl From<GetAssetsByGroupV0> for GetAssetsByGroup {
             before: value.before,
             after: value.after,
             cursor: None,
-            options: Default::default(),
+            options: GetByMethodsOptions {
+                show_unverified_collections: true,
+                ..Default::default()
+            },
         }
     }
 }

--- a/nft_ingester/src/api/builder.rs
+++ b/nft_ingester/src/api/builder.rs
@@ -1,8 +1,9 @@
 use std::sync::Arc;
 
 use entities::api_req_params::{
-    GetAssetBatchV0, GetAssetV0, GetAssetsByAuthorityV0, GetAssetsByCreatorV0, GetAssetsByGroupV0,
-    GetAssetsByOwnerV0, SearchAssetsV0,
+    GetAsset, GetAssetBatch, GetAssetBatchV0, GetAssetV0, GetAssetsByAuthority,
+    GetAssetsByAuthorityV0, GetAssetsByCreator, GetAssetsByCreatorV0, GetAssetsByGroup,
+    GetAssetsByGroupV0, GetAssetsByOwner, GetAssetsByOwnerV0, SearchAssets, SearchAssetsV0,
 };
 use interface::consistency_check::ConsistencyChecker;
 use jsonrpc_core::{types::params::Params, MetaIoHandler};
@@ -63,10 +64,13 @@ impl RpcApiBuilder {
             let api = cloned_api.clone();
             let tasks = cloned_tasks.clone();
             async move {
-                if let Ok(params) = rpc_params.clone().parse::<GetAssetV0>() {
-                    return api.get_asset(params.into(), tasks).await.map_err(Into::into);
-                };
-                api.get_asset(rpc_params.parse()?, tasks).await.map_err(Into::into)
+                match rpc_params.clone().parse::<GetAsset>() {
+                    Ok(payload) => api.get_asset(payload, tasks).await.map_err(Into::into),
+                    Err(_) => api
+                        .get_asset(rpc_params.parse::<GetAssetV0>()?.into(), tasks)
+                        .await
+                        .map_err(Into::into),
+                }
             }
         });
         module.add_alias("getAsset", "get_asset");
@@ -77,10 +81,18 @@ impl RpcApiBuilder {
             let api = cloned_api.clone();
             let tasks = cloned_tasks.clone();
             async move {
-                if let Ok(params) = rpc_params.clone().parse::<GetAssetsByOwnerV0>() {
-                    return api.get_assets_by_owner(params.into(), tasks).await.map_err(Into::into);
-                };
-                api.get_assets_by_owner(rpc_params.parse()?, tasks).await.map_err(Into::into)
+                match rpc_params.clone().parse::<GetAssetsByOwner>() {
+                    Ok(payload) => {
+                        api.get_assets_by_owner(payload, tasks).await.map_err(Into::into)
+                    },
+                    Err(_) => api
+                        .get_assets_by_owner(
+                            rpc_params.parse::<GetAssetsByOwnerV0>()?.into(),
+                            tasks,
+                        )
+                        .await
+                        .map_err(Into::into),
+                }
             }
         });
         module.add_alias("getAssetsByOwner", "get_assets_by_owner");
@@ -91,13 +103,18 @@ impl RpcApiBuilder {
             let api = cloned_api.clone();
             let tasks = cloned_tasks.clone();
             async move {
-                if let Ok(params) = rpc_params.clone().parse::<GetAssetsByCreatorV0>() {
-                    return api
-                        .get_assets_by_creator(params.into(), tasks)
+                match rpc_params.clone().parse::<GetAssetsByCreator>() {
+                    Ok(payload) => {
+                        api.get_assets_by_creator(payload, tasks).await.map_err(Into::into)
+                    },
+                    Err(_) => api
+                        .get_assets_by_creator(
+                            rpc_params.parse::<GetAssetsByCreatorV0>()?.into(),
+                            tasks,
+                        )
                         .await
-                        .map_err(Into::into);
-                };
-                api.get_assets_by_creator(rpc_params.parse()?, tasks).await.map_err(Into::into)
+                        .map_err(Into::into),
+                }
             }
         });
         module.add_alias("getAssetsByCreator", "get_assets_by_creator");
@@ -108,13 +125,18 @@ impl RpcApiBuilder {
             let api = cloned_api.clone();
             let tasks = cloned_tasks.clone();
             async move {
-                if let Ok(params) = rpc_params.clone().parse::<GetAssetsByAuthorityV0>() {
-                    return api
-                        .get_assets_by_authority(params.into(), tasks)
+                match rpc_params.clone().parse::<GetAssetsByAuthority>() {
+                    Ok(payload) => {
+                        api.get_assets_by_authority(payload, tasks).await.map_err(Into::into)
+                    },
+                    Err(_) => api
+                        .get_assets_by_authority(
+                            rpc_params.parse::<GetAssetsByAuthorityV0>()?.into(),
+                            tasks,
+                        )
                         .await
-                        .map_err(Into::into);
-                };
-                api.get_assets_by_authority(rpc_params.parse()?, tasks).await.map_err(Into::into)
+                        .map_err(Into::into),
+                }
             }
         });
         module.add_alias("getAssetsByAuthority", "get_assets_by_authority");
@@ -125,10 +147,18 @@ impl RpcApiBuilder {
             let api = cloned_api.clone();
             let tasks = cloned_tasks.clone();
             async move {
-                if let Ok(params) = rpc_params.clone().parse::<GetAssetsByGroupV0>() {
-                    return api.get_assets_by_group(params.into(), tasks).await.map_err(Into::into);
-                };
-                api.get_assets_by_group(rpc_params.parse()?, tasks).await.map_err(Into::into)
+                match rpc_params.clone().parse::<GetAssetsByGroup>() {
+                    Ok(payload) => {
+                        api.get_assets_by_group(payload, tasks).await.map_err(Into::into)
+                    },
+                    Err(_) => api
+                        .get_assets_by_group(
+                            rpc_params.parse::<GetAssetsByGroupV0>()?.into(),
+                            tasks,
+                        )
+                        .await
+                        .map_err(Into::into),
+                }
             }
         });
         module.add_alias("getAssetsByGroup", "get_assets_by_group");
@@ -139,10 +169,13 @@ impl RpcApiBuilder {
             let api = cloned_api.clone();
             let tasks = cloned_tasks.clone();
             async move {
-                if let Ok(params) = rpc_params.clone().parse::<GetAssetBatchV0>() {
-                    return api.get_asset_batch(params.into(), tasks).await.map_err(Into::into);
-                };
-                api.get_asset_batch(rpc_params.parse()?, tasks).await.map_err(Into::into)
+                match rpc_params.clone().parse::<GetAssetBatch>() {
+                    Ok(payload) => api.get_asset_batch(payload, tasks).await.map_err(Into::into),
+                    Err(_) => api
+                        .get_asset_batch(rpc_params.parse::<GetAssetBatchV0>()?.into(), tasks)
+                        .await
+                        .map_err(Into::into),
+                }
             }
         });
         module.add_alias("getAssetBatch", "get_asset_batch");
@@ -171,10 +204,13 @@ impl RpcApiBuilder {
             let api = cloned_api.clone();
             let tasks = cloned_tasks.clone();
             async move {
-                if let Ok(params) = rpc_params.clone().parse::<SearchAssetsV0>() {
-                    return api.search_assets(params.into(), tasks).await.map_err(Into::into);
-                };
-                api.search_assets(rpc_params.parse()?, tasks).await.map_err(Into::into)
+                match rpc_params.clone().parse::<SearchAssets>() {
+                    Ok(payload) => api.search_assets(payload, tasks).await.map_err(Into::into),
+                    Err(_) => api
+                        .search_assets(rpc_params.parse::<SearchAssetsV0>()?.into(), tasks)
+                        .await
+                        .map_err(Into::into),
+                }
             }
         });
         module.add_alias("searchAssets", "search_assets");

--- a/nft_ingester/tests/api_tests.rs
+++ b/nft_ingester/tests/api_tests.rs
@@ -4208,10 +4208,7 @@ mod tests {
                 page: None,
                 before: None,
                 after: None,
-                options: GetByMethodsOptions {
-                    show_unverified_collections: true,
-                    ..Default::default()
-                },
+                options: Default::default(),
                 cursor: None
             }
         );
@@ -4232,10 +4229,7 @@ mod tests {
                 page: None,
                 before: None,
                 after: None,
-                options: GetByMethodsOptions {
-                    show_unverified_collections: true,
-                    ..Default::default()
-                },
+                options: Default::default(),
                 cursor: None
             }
         );
@@ -4255,10 +4249,7 @@ mod tests {
                 page: None,
                 before: None,
                 after: None,
-                options: GetByMethodsOptions {
-                    show_unverified_collections: true,
-                    ..Default::default()
-                },
+                options: Default::default(),
                 cursor: None
             }
         );
@@ -4279,10 +4270,7 @@ mod tests {
                 page: None,
                 before: None,
                 after: None,
-                options: GetByMethodsOptions {
-                    show_unverified_collections: true,
-                    ..Default::default()
-                },
+                options: Default::default(),
                 cursor: None
             }
         );
@@ -4297,10 +4285,7 @@ mod tests {
             Into::<GetAssetBatch>::into(params_deserialized),
             GetAssetBatch {
                 ids: vec!["asset1".to_owned(), "asset2".to_owned()],
-                options: entities::api_req_params::Options {
-                    show_unverified_collections: true,
-                    ..Default::default()
-                },
+                options: Default::default(),
             }
         );
         // getAsset
@@ -4312,13 +4297,7 @@ mod tests {
             .expect("params provided deserialize correctly into GetAssetsByOwner");
         assert_eq!(
             Into::<GetAsset>::into(params_deserialized),
-            GetAsset {
-                id: "asset".to_owned(),
-                options: entities::api_req_params::Options {
-                    show_unverified_collections: true,
-                    ..Default::default()
-                },
-            }
+            GetAsset { id: "asset".to_owned(), options: Default::default() }
         );
     }
 }

--- a/nft_ingester/tests/api_tests.rs
+++ b/nft_ingester/tests/api_tests.rs
@@ -16,10 +16,11 @@ mod tests {
     };
     use entities::{
         api_req_params::{
-            AssetSortBy, AssetSortDirection, AssetSorting, DisplayOptions, GetAsset, GetAssetProof,
-            GetAssetSignatures, GetAssetsByAuthority, GetAssetsByCreator, GetAssetsByGroup,
-            GetAssetsByOwner, GetByMethodsOptions, GetCoreFees, GetTokenAccounts, Options,
-            SearchAssets, SearchAssetsOptions,
+            AssetSortBy, AssetSortDirection, AssetSorting, DisplayOptions, GetAsset, GetAssetBatch,
+            GetAssetBatchV0, GetAssetProof, GetAssetSignatures, GetAssetV0, GetAssetsByAuthority,
+            GetAssetsByAuthorityV0, GetAssetsByCreator, GetAssetsByCreatorV0, GetAssetsByGroup,
+            GetAssetsByGroupV0, GetAssetsByOwner, GetAssetsByOwnerV0, GetByMethodsOptions,
+            GetCoreFees, GetTokenAccounts, Options, SearchAssets, SearchAssetsOptions,
         },
         enums::{
             AssetType, ChainMutability, Interface, OwnerType, OwnershipModel, RoyaltyModel,
@@ -4185,6 +4186,139 @@ mod tests {
             res.items.len(),
             2,
             "SearchAssets by token_type: NonFungible, show_zero_balance: false"
+        );
+    }
+
+    #[test]
+    fn v1_payloads_are_parsed_correctly_from_v0_payloads() {
+        // getAssetsByAuthority
+        let request_params =
+            r#"["DASPQfEAVcHp55eFmfstRduMT3dSfoTirFFsMHwUaWaz",null,null,null,null,null]"#;
+        let rpc_params: jsonrpc_core::Params =
+            serde_json::from_str(request_params).expect("params are valid json");
+        let params_deserialized: GetAssetsByAuthorityV0 = rpc_params
+            .parse()
+            .expect("params provided deserialize correctly into GetAssetsByAuthority");
+        assert_eq!(
+            Into::<GetAssetsByAuthority>::into(params_deserialized),
+            GetAssetsByAuthority {
+                authority_address: "DASPQfEAVcHp55eFmfstRduMT3dSfoTirFFsMHwUaWaz".to_owned(),
+                sort_by: None,
+                limit: None,
+                page: None,
+                before: None,
+                after: None,
+                options: GetByMethodsOptions {
+                    show_unverified_collections: true,
+                    ..Default::default()
+                },
+                cursor: None
+            }
+        );
+        // getAssetsByGroup
+        let request_params = r#"["something","else",null,null,null,null,null]"#;
+        let rpc_params: jsonrpc_core::Params =
+            serde_json::from_str(request_params).expect("params are valid json");
+        let params_deserialized: GetAssetsByGroupV0 = rpc_params
+            .parse()
+            .expect("params provided deserialize correctly into GetAssetsByGroup");
+        assert_eq!(
+            Into::<GetAssetsByGroup>::into(params_deserialized),
+            GetAssetsByGroup {
+                group_key: "something".to_owned(),
+                group_value: "else".to_owned(),
+                sort_by: None,
+                limit: None,
+                page: None,
+                before: None,
+                after: None,
+                options: GetByMethodsOptions {
+                    show_unverified_collections: true,
+                    ..Default::default()
+                },
+                cursor: None
+            }
+        );
+        // getAssetsByOwner
+        let request_params = r#"["owner",null,null,null,null,null]"#;
+        let rpc_params: jsonrpc_core::Params =
+            serde_json::from_str(request_params).expect("params are valid json");
+        let params_deserialized: GetAssetsByOwnerV0 = rpc_params
+            .parse()
+            .expect("params provided deserialize correctly into GetAssetsByOwner");
+        assert_eq!(
+            Into::<GetAssetsByOwner>::into(params_deserialized),
+            GetAssetsByOwner {
+                owner_address: "owner".to_owned(),
+                sort_by: None,
+                limit: None,
+                page: None,
+                before: None,
+                after: None,
+                options: GetByMethodsOptions {
+                    show_unverified_collections: true,
+                    ..Default::default()
+                },
+                cursor: None
+            }
+        );
+        // getAssetsByCreator
+        let request_params = r#"["creator_address",false,null,null,null,null,null]"#;
+        let rpc_params: jsonrpc_core::Params =
+            serde_json::from_str(request_params).expect("params are valid json");
+        let params_deserialized: GetAssetsByCreatorV0 = rpc_params
+            .parse()
+            .expect("params provided deserialize correctly into GetAssetsByOwner");
+        assert_eq!(
+            Into::<GetAssetsByCreator>::into(params_deserialized),
+            GetAssetsByCreator {
+                creator_address: "creator_address".to_owned(),
+                only_verified: Some(false),
+                sort_by: None,
+                limit: None,
+                page: None,
+                before: None,
+                after: None,
+                options: GetByMethodsOptions {
+                    show_unverified_collections: true,
+                    ..Default::default()
+                },
+                cursor: None
+            }
+        );
+        // getAssets
+        let request_params = r#"[["asset1","asset2"]]"#;
+        let rpc_params: jsonrpc_core::Params =
+            serde_json::from_str(request_params).expect("params are valid json");
+        let params_deserialized: GetAssetBatchV0 = rpc_params
+            .parse()
+            .expect("params provided deserialize correctly into GetAssetsByOwner");
+        assert_eq!(
+            Into::<GetAssetBatch>::into(params_deserialized),
+            GetAssetBatch {
+                ids: vec!["asset1".to_owned(), "asset2".to_owned()],
+                options: entities::api_req_params::Options {
+                    show_unverified_collections: true,
+                    ..Default::default()
+                },
+            }
+        );
+        // getAsset
+        let request_params = r#"["asset"]"#;
+        let rpc_params: jsonrpc_core::Params =
+            serde_json::from_str(request_params).expect("params are valid json");
+        let params_deserialized: GetAssetV0 = rpc_params
+            .parse()
+            .expect("params provided deserialize correctly into GetAssetsByOwner");
+        assert_eq!(
+            Into::<GetAsset>::into(params_deserialized),
+            GetAsset {
+                id: "asset".to_owned(),
+                options: entities::api_req_params::Options {
+                    show_unverified_collections: true,
+                    ..Default::default()
+                },
+            }
         );
     }
 }


### PR DESCRIPTION
Two things are changed in this PR:
1) V1 payload parsing is prioritized over V0 as for V0 we do not parse `displayOptions` at all.
2) `showUnverifiedCollections` now defaults to `false`.