### PR TITLE
feat: overhaul task spawning in the whole project

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1676,7 +1676,7 @@ dependencies = [
  "anchor-lang 0.29.0",
  "async-trait",
  "blockbuster",
- "borsh 0.9.3",
+ "borsh 0.10.3",
  "bytemuck",
  "chrono",
  "mpl-bubblegum",
@@ -2067,7 +2067,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]
@@ -2107,7 +2107,7 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tracing",
  "tracing-subscriber",
  "usecase",
@@ -3344,7 +3344,7 @@ dependencies = [
  "indexmap 2.2.6",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tracing",
 ]
 
@@ -3874,6 +3874,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.13",
  "tracing",
  "tracing-test",
  "usecase",
@@ -3907,7 +3908,7 @@ dependencies = [
  "spl-concurrent-merkle-tree 0.2.0",
  "thiserror",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tracing",
  "usecase",
 ]
@@ -3934,6 +3935,7 @@ dependencies = [
  "solana-transaction-status",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.13",
 ]
 
 [[package]]
@@ -4856,7 +4858,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-retry",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tonic 0.10.2",
  "tracing",
  "tracing-subscriber",
@@ -6326,7 +6328,7 @@ dependencies = [
  "sha1_smol",
  "tokio",
  "tokio-native-tls",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "url",
 ]
 
@@ -6448,7 +6450,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -6562,6 +6564,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tokio-stream",
+ "tokio-util 0.7.13",
  "tracing",
  "tracing-test",
  "usecase",
@@ -7136,6 +7139,7 @@ dependencies = [
  "testcontainers",
  "testcontainers-modules",
  "tokio",
+ "tokio-util 0.7.13",
  "tracing",
  "uuid 1.8.0",
 ]
@@ -9798,9 +9802,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
@@ -9901,7 +9905,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.23.4",
  "tokio-stream",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tower",
  "tower-layer",
  "tower-service",
@@ -10020,7 +10024,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -10396,6 +10400,7 @@ dependencies = [
  "spl-concurrent-merkle-tree 0.4.1",
  "thiserror",
  "tokio",
+ "tokio-util 0.7.13",
  "tracing",
 ]
 
@@ -10522,7 +10527,7 @@ dependencies = [
  "serde_urlencoded",
  "tokio",
  "tokio-tungstenite 0.21.0",
- "tokio-util 0.7.11",
+ "tokio-util 0.7.13",
  "tower-service",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,10 @@ members = [
 [workspace.dependencies]
 
 # Tokio ecosystem
-tokio = { version = "1.37.0", features = ["full", "tracing"] }
-tokio-stream = "0.1.11"
-tokio-util = { version = "0.7.13", features = ["codec", "compat"] }
-tokio-retry = "0.3.0"
+tokio = { version = "1.37", features = ["full", "tracing"] }
+tokio-stream = "0.1"
+tokio-util = { version = "0.7", features = ["codec", "compat"] }
+tokio-retry = "0.3"
 
 
 # Serde ecosystem and seryalization tools

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 # Tokio ecosystem
 tokio = { version = "1.37.0", features = ["full", "tracing"] }
 tokio-stream = "0.1.11"
-tokio-util = { version = "0.7.10", features = ["codec", "compat"] }
+tokio-util = { version = "0.7.13", features = ["codec", "compat"] }
 tokio-retry = "0.3.0"
 
 

--- a/backfill_rpc/src/rpc.rs
+++ b/backfill_rpc/src/rpc.rs
@@ -346,7 +346,7 @@ mod tests {
         });
 
         let (addr, server) = warp::serve(route).bind_ephemeral(([127, 0, 0, 1], 0));
-        let _server_handle = tokio::spawn(server);
+        let _server_handle = usecase::executor::spawn(server);
 
         let client =
             RpcClient::new_sender(TooManyRequestsRpcSender(addr.to_string()), Default::default());
@@ -373,7 +373,7 @@ mod tests {
         });
 
         let (addr, server) = warp::serve(route).bind_ephemeral(([127, 0, 0, 1], 0));
-        let _server_handle = tokio::spawn(server);
+        let _server_handle = usecase::executor::spawn(server);
 
         let client =
             RpcClient::new_sender(TooManyRequestsRpcSender(addr.to_string()), Default::default());

--- a/consistency_check/src/lib.rs
+++ b/consistency_check/src/lib.rs
@@ -7,7 +7,7 @@ use tokio::sync::Mutex;
 use tokio_util::sync::CancellationToken;
 
 pub async fn update_rate(
-    shutdown_token: CancellationToken,
+    cancellation_token: CancellationToken,
     assets_processed: Arc<AtomicU64>,
     rate: Arc<Mutex<f64>>,
 ) {
@@ -19,7 +19,7 @@ pub async fn update_rate(
 
         tokio::select! {
             _ = sleep => {}
-            _ = shutdown_token.cancelled() => {break;}
+            _ = cancellation_token.cancelled() => { break; }
         }
 
         let current_time = std::time::Instant::now();

--- a/integration_tests/Cargo.toml
+++ b/integration_tests/Cargo.toml
@@ -27,6 +27,7 @@ spl-token = { workspace = true, features = ["no-entrypoint"] }
 sqlx = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 rocksdb = { workspace = true }
 tempfile = {workspace = true}
 env_logger = { workspace = true }

--- a/integration_tests/src/cnft_tests.rs
+++ b/integration_tests/src/cnft_tests.rs
@@ -1,11 +1,10 @@
-use std::{collections::HashMap, str::FromStr, sync::Arc};
+use std::{collections::HashMap, str::FromStr};
 
 use entities::api_req_params::{GetAsset, Options, SearchAssets};
 use function_name::named;
 use itertools::Itertools;
 use serial_test::serial;
 use solana_sdk::signature::Signature;
-use tokio::{sync::Mutex, task::JoinSet};
 
 use super::common::*;
 
@@ -23,18 +22,16 @@ pub async fn run_get_asset_scenario_test(
         Order::Forward => vec![seeds.iter().collect_vec()],
     };
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     for events in seed_permutations {
         index_seed_events(setup, events).await;
         let request = GetAsset { id: asset_id.to_string(), options: options.clone() };
 
-        let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+        let response = setup.das_api.get_asset(request).await.unwrap();
         insta::assert_json_snapshot!(setup.name.clone(), response);
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[tracing_test::traced_test]
 #[serial]
 #[named]
@@ -76,7 +73,7 @@ async fn test_asset_decompress() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_cnft_scenario_mint_update_metadata() {
@@ -110,7 +107,7 @@ async fn test_cnft_scenario_mint_update_metadata() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_cnft_scenario_mint_update_metadata_remove_creators() {
@@ -146,7 +143,7 @@ async fn test_cnft_scenario_mint_update_metadata_remove_creators() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_cnft_owners_table() {
@@ -170,8 +167,6 @@ async fn test_cnft_owners_table() {
         index_transaction(&setup, Signature::from_str(txn).unwrap()).await;
     }
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     for (request, individual_test_name) in [
         (
             SearchAssets {
@@ -192,13 +187,12 @@ async fn test_cnft_owners_table() {
             "with_different_owner",
         ),
     ] {
-        let response =
-            setup.das_api.search_assets(request.clone(), mutexed_tasks.clone()).await.unwrap();
+        let response = setup.das_api.search_assets(request.clone()).await.unwrap();
         insta::assert_json_snapshot!(format!("{}-{}", name, individual_test_name), response);
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_no_json_uri() {
@@ -225,7 +219,7 @@ async fn test_mint_no_json_uri() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_delegate_transfer() {
@@ -258,7 +252,7 @@ async fn test_mint_delegate_transfer() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_redeem_cancel_redeem() {
@@ -291,7 +285,7 @@ async fn test_mint_redeem_cancel_redeem() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_redeem() {
@@ -329,7 +323,7 @@ async fn test_mint_redeem() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_transfer_burn() {
@@ -362,7 +356,7 @@ async fn test_mint_transfer_burn() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_transfer_noop() {
@@ -395,7 +389,7 @@ async fn test_mint_transfer_noop() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_transfer_transfer() {
@@ -428,7 +422,7 @@ async fn test_mint_transfer_transfer() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_verify_creator() {
@@ -460,7 +454,7 @@ async fn test_mint_verify_creator() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_verify_collection() {
@@ -492,7 +486,7 @@ async fn test_mint_verify_collection() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_transfer_mpl_programs() {
@@ -525,7 +519,7 @@ async fn test_mint_transfer_mpl_programs() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_to_collection_unverify_collection() {
@@ -562,7 +556,7 @@ async fn test_mint_to_collection_unverify_collection() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mint_verify_collection_unverify_collection() {

--- a/integration_tests/src/common.rs
+++ b/integration_tests/src/common.rs
@@ -14,7 +14,7 @@ use nft_ingester::{
     api::{account_balance::AccountBalanceGetterImpl, DasApi},
     buffer::Buffer,
     config::JsonMiddlewareConfig,
-    index_syncronizer::Synchronizer,
+    index_synchronizer::Synchronizer,
     init::init_index_storage_with_migration,
     json_worker::JsonWorker,
     message_parser::MessageParser,
@@ -46,11 +46,8 @@ use solana_sdk::{
     signature::Signature,
 };
 use solana_transaction_status::{EncodedConfirmedTransactionWithStatusMeta, UiTransactionEncoding};
-use tokio::{
-    sync::{broadcast, Mutex},
-    task::JoinSet,
-    time::{sleep, Instant},
-};
+use tokio::time::{sleep, Instant};
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 use usecase::proofs::MaybeProofChecker;
 
@@ -99,10 +96,6 @@ pub struct TestSetup {
 }
 
 impl TestSetup {
-    pub async fn new(name: String) -> Self {
-        Self::new_with_options(name, TestSetupOptions::default()).await
-    }
-
     pub async fn new_with_options(name: String, opts: TestSetupOptions) -> Self {
         let red_metrics = Arc::new(metrics_utils::red::RequestErrorDurationMetrics::new());
 
@@ -130,23 +123,18 @@ impl TestSetup {
         };
         let client = Arc::new(RpcClient::new(rpc_url.to_string()));
 
-        let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
         let buffer = Arc::new(Buffer::new());
 
         let metrics_state = MetricState::new();
 
-        let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
         let acc_processor = AccountsProcessor::build(
-            shutdown_rx.resubscribe(),
+            CancellationToken::new(),
             ACC_PROCESSOR_FETCH_BATCH_SIZE,
             buffer.clone(),
             metrics_state.ingester_metrics.clone(),
             None,
             index_storage.clone(),
             client.clone(),
-            mutexed_tasks.clone(),
             None,
             opts.well_known_fungible_accounts,
         )
@@ -160,13 +148,7 @@ impl TestSetup {
         }
 
         let storage = Arc::new(
-            Storage::open(
-                rocks_db_dir.path(),
-                mutexed_tasks.clone(),
-                red_metrics.clone(),
-                MigrationState::Last,
-            )
-            .unwrap(),
+            Storage::open(rocks_db_dir.path(), red_metrics.clone(), MigrationState::Last).unwrap(),
         );
 
         let tx_processor =
@@ -412,10 +394,18 @@ pub async fn get_token_largest_account(client: &RpcClient, mint: Pubkey) -> anyh
 pub async fn index_and_sync_account_bytes(setup: &TestSetup, account_bytes: Vec<u8>) {
     process_and_save_accounts_to_rocks(setup, account_bytes).await;
 
-    let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
+    let cancellation_token = CancellationToken::new();
     // copy data to Postgre
-    setup.synchronizer.synchronize_nft_asset_indexes(&shutdown_rx, 1000).await.unwrap();
-    setup.synchronizer.synchronize_fungible_asset_indexes(&shutdown_rx, 1000).await.unwrap();
+    setup
+        .synchronizer
+        .synchronize_nft_asset_indexes(cancellation_token.child_token(), 1000)
+        .await
+        .unwrap();
+    setup
+        .synchronizer
+        .synchronize_fungible_asset_indexes(cancellation_token.child_token(), 1000)
+        .await
+        .unwrap();
 }
 
 async fn process_and_save_accounts_to_rocks(setup: &TestSetup, account_bytes: Vec<u8>) {
@@ -512,10 +502,13 @@ pub async fn index_transaction(setup: &TestSetup, sig: Signature) {
         .await
         .unwrap();
 
-    let (_shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-    setup.synchronizer.synchronize_nft_asset_indexes(&shutdown_rx, 1000).await.unwrap();
+    setup.synchronizer.synchronize_nft_asset_indexes(CancellationToken::new(), 1000).await.unwrap();
 
-    setup.synchronizer.synchronize_fungible_asset_indexes(&shutdown_rx, 1000).await.unwrap();
+    setup
+        .synchronizer
+        .synchronize_fungible_asset_indexes(CancellationToken::new(), 1000)
+        .await
+        .unwrap();
 }
 
 async fn cached_fetch_largest_token_account_id(client: &RpcClient, mint: Pubkey) -> Pubkey {
@@ -550,6 +543,7 @@ pub enum Network {
     Mainnet,
     Devnet,
     EclipseMainnet,
+    #[allow(unused)]
     EclipseDevnet,
 }
 

--- a/integration_tests/src/lib.rs
+++ b/integration_tests/src/lib.rs
@@ -1,10 +1,16 @@
-#![allow(unused)]
-
+#[cfg(test)]
 mod account_update_tests;
+#[cfg(test)]
 mod cnft_tests;
+#[cfg(test)]
 mod common;
+#[cfg(test)]
 mod general_scenario_tests;
+#[cfg(test)]
 mod mpl_core_tests;
+#[cfg(test)]
 mod regular_nft_tests;
+#[cfg(test)]
 mod synchronizer_tests;
+#[cfg(test)]
 mod token_tests;

--- a/integration_tests/src/mpl_core_tests.rs
+++ b/integration_tests/src/mpl_core_tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use entities::api_req_params::{
     GetAsset, GetAssetsByAuthority, GetAssetsByGroup, GetAssetsByOwner,
@@ -6,11 +6,10 @@ use entities::api_req_params::{
 use function_name::named;
 use itertools::Itertools;
 use serial_test::serial;
-use tokio::{sync::Mutex, task::JoinSet};
 
 use super::common::*;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset() {
@@ -35,14 +34,12 @@ async fn test_mpl_core_get_asset() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_collection() {
@@ -67,14 +64,12 @@ async fn test_mpl_core_get_collection() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_assets_by_authority() {
@@ -110,15 +105,12 @@ async fn test_mpl_core_get_assets_by_authority() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByAuthority = serde_json::from_str(request).unwrap();
-    let response =
-        setup.das_api.get_assets_by_authority(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_authority(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_assets_by_group() {
@@ -155,14 +147,12 @@ async fn test_mpl_core_get_assets_by_group() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByGroup = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_assets_by_group(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_group(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_assets_by_owner() {
@@ -196,14 +186,12 @@ async fn test_mpl_core_get_assets_by_owner() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByOwner = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_assets_by_owner(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_owner(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_edition() {
@@ -228,14 +216,12 @@ async fn test_mpl_core_get_asset_with_edition() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_pubkey_in_rule_set() {
@@ -260,14 +246,12 @@ async fn test_mpl_core_get_asset_with_pubkey_in_rule_set() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_two_oracle_external_plugins() {
@@ -292,14 +276,12 @@ async fn test_mpl_core_get_asset_with_two_oracle_external_plugins() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_oracle_external_plugin_on_collection() {
@@ -324,14 +306,12 @@ async fn test_mpl_core_get_asset_with_oracle_external_plugin_on_collection() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_oracle_multiple_lifecycle_events() {
@@ -356,14 +336,12 @@ async fn test_mpl_core_get_asset_with_oracle_multiple_lifecycle_events() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_oracle_custom_offset_and_base_address_config() {
@@ -388,14 +366,12 @@ async fn test_mpl_core_get_asset_with_oracle_custom_offset_and_base_address_conf
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_oracle_no_offset() {
@@ -420,14 +396,12 @@ async fn test_mpl_core_get_asset_with_oracle_no_offset() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_assets_by_group_with_oracle_and_custom_pda_all_seeds() {
@@ -462,14 +436,12 @@ async fn test_mpl_core_get_assets_by_group_with_oracle_and_custom_pda_all_seeds(
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByGroup = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_assets_by_group(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_group(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_multiple_internal_and_external_plugins() {
@@ -494,14 +466,12 @@ async fn test_mpl_core_get_asset_with_multiple_internal_and_external_plugins() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_autograph_plugin() {
@@ -526,14 +496,12 @@ async fn test_mpl_core_autograph_plugin() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_autograph_plugin_with_signature() {
@@ -558,14 +526,12 @@ async fn test_mpl_core_autograph_plugin_with_signature() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_verified_creators_plugin() {
@@ -590,14 +556,12 @@ async fn test_mpl_core_verified_creators_plugin() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_verified_creators_plugin_with_signature() {
@@ -622,14 +586,12 @@ async fn test_mpl_core_verified_creators_plugin_with_signature() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_app_data_with_binary_data_and_owner_is_data_authority() {
@@ -654,14 +616,12 @@ async fn test_mpl_core_get_asset_with_app_data_with_binary_data_and_owner_is_dat
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_app_data_with_json_data_and_update_authority_is_data_authority(
@@ -687,14 +647,12 @@ async fn test_mpl_core_get_asset_with_app_data_with_json_data_and_update_authori
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_app_data_with_msg_pack_data_and_address_is_data_authority() {
@@ -719,14 +677,12 @@ async fn test_mpl_core_get_asset_with_app_data_with_msg_pack_data_and_address_is
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_collection_with_linked_app_data_with_binary_data_and_address_is_data_authority(
@@ -752,14 +708,12 @@ async fn test_mpl_core_get_collection_with_linked_app_data_with_binary_data_and_
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_data_section_with_binary_data() {
@@ -784,14 +738,12 @@ async fn test_mpl_core_get_asset_with_data_section_with_binary_data() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_collection_with_linked_app_data_with_json_data_and_owner_is_data_authority(
@@ -817,14 +769,12 @@ async fn test_mpl_core_get_collection_with_linked_app_data_with_json_data_and_ow
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_data_section_with_json_data() {
@@ -849,14 +799,12 @@ async fn test_mpl_core_get_asset_with_data_section_with_json_data() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_collection_with_linked_app_data_with_msg_pack_data_and_update_authority_is_data_authority(
@@ -882,14 +830,12 @@ async fn test_mpl_core_get_collection_with_linked_app_data_with_msg_pack_data_an
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_mpl_core_get_asset_with_data_section_with_msg_pack_data() {
@@ -914,9 +860,7 @@ async fn test_mpl_core_get_asset_with_data_section_with_msg_pack_data() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_asset(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }

--- a/integration_tests/src/synchronizer_tests.rs
+++ b/integration_tests/src/synchronizer_tests.rs
@@ -1,23 +1,17 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
 use entities::{
-    api_req_params::{
-        GetAsset, GetAssetBatch, GetAssetsByAuthority, GetAssetsByGroup, GetAssetsByOwner,
-        SearchAssets,
-    },
+    api_req_params::{GetAssetsByAuthority, GetAssetsByGroup, GetAssetsByOwner},
     enums::AssetType,
 };
 use function_name::named;
 use itertools::Itertools;
 use serial_test::serial;
-use tokio::{
-    sync::{broadcast, Mutex},
-    task::JoinSet,
-};
+use tokio_util::sync::CancellationToken;
 
 use super::common::*;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_full_sync_core_get_assets_by_authority() {
@@ -41,11 +35,9 @@ async fn test_full_sync_core_get_assets_by_authority() {
 
     single_db_index_seed_events(&setup, seeds.iter().collect_vec()).await;
 
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
     setup
         .synchronizer
-        .full_syncronize(&shutdown_rx.resubscribe(), AssetType::NonFungible)
+        .full_syncronize(CancellationToken::new(), AssetType::NonFungible)
         .await
         .unwrap();
 
@@ -61,15 +53,12 @@ async fn test_full_sync_core_get_assets_by_authority() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByAuthority = serde_json::from_str(request).unwrap();
-    let response =
-        setup.das_api.get_assets_by_authority(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_authority(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_full_sync_core_get_assets_by_group() {
@@ -93,11 +82,9 @@ async fn test_full_sync_core_get_assets_by_group() {
 
     single_db_index_seed_events(&setup, seeds.iter().collect_vec()).await;
 
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
     setup
         .synchronizer
-        .full_syncronize(&shutdown_rx.resubscribe(), AssetType::NonFungible)
+        .full_syncronize(CancellationToken::new(), AssetType::NonFungible)
         .await
         .unwrap();
 
@@ -114,14 +101,12 @@ async fn test_full_sync_core_get_assets_by_group() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByGroup = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_assets_by_group(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_group(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_full_sync_core_get_assets_by_owner() {
@@ -143,11 +128,9 @@ async fn test_full_sync_core_get_assets_by_owner() {
 
     single_db_index_seed_events(&setup, seeds.iter().collect_vec()).await;
 
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
     setup
         .synchronizer
-        .full_syncronize(&shutdown_rx.resubscribe(), AssetType::NonFungible)
+        .full_syncronize(CancellationToken::new(), AssetType::NonFungible)
         .await
         .unwrap();
 
@@ -163,14 +146,12 @@ async fn test_full_sync_core_get_assets_by_owner() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByOwner = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_assets_by_owner(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_owner(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_full_sync_core_and_regular_nfts_get_assets_by_owner() {
@@ -197,11 +178,9 @@ async fn test_full_sync_core_and_regular_nfts_get_assets_by_owner() {
 
     single_db_index_seed_events(&setup, seeds.iter().collect_vec()).await;
 
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
     setup
         .synchronizer
-        .full_syncronize(&shutdown_rx.resubscribe(), AssetType::NonFungible)
+        .full_syncronize(CancellationToken::new(), AssetType::NonFungible)
         .await
         .unwrap();
 
@@ -217,9 +196,7 @@ async fn test_full_sync_core_and_regular_nfts_get_assets_by_owner() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAssetsByOwner = serde_json::from_str(request).unwrap();
-    let response = setup.das_api.get_assets_by_owner(request, mutexed_tasks.clone()).await.unwrap();
+    let response = setup.das_api.get_assets_by_owner(request).await.unwrap();
     insta::assert_json_snapshot!(name, response);
 }

--- a/integration_tests/src/token_tests.rs
+++ b/integration_tests/src/token_tests.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use entities::api_req_params::GetAsset;
 use function_name::named;
 use itertools::Itertools;

--- a/integration_tests/src/token_tests.rs
+++ b/integration_tests/src/token_tests.rs
@@ -1,24 +1,17 @@
-use std::{collections::HashMap, sync::Arc};
+use std::collections::HashMap;
 
-use entities::{api_req_params::GetAsset, enums::AssetType};
+use entities::api_req_params::GetAsset;
 use function_name::named;
 use itertools::Itertools;
-use nft_ingester::api::dapi::{
-    response::{AssetList, TokenAccountsList},
-    rpc_asset_models::Asset,
-};
+use nft_ingester::api::dapi::rpc_asset_models::Asset;
 use serial_test::serial;
-use tokio::{
-    sync::{broadcast, Mutex},
-    task::JoinSet,
-};
 
 use crate::common::{
     index_seed_events, seed_token_mints, trim_test_name, well_known_fungible_tokens, Network,
     SeedEvent, TestSetup, TestSetupOptions,
 };
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread")]
 #[serial]
 #[named]
 async fn test_fungible_token_mint_freeze_authority() {
@@ -44,10 +37,8 @@ async fn test_fungible_token_mint_freeze_authority() {
     }
     "#;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-
     let request: GetAsset = serde_json::from_str(request).unwrap();
-    let response_value = setup.das_api.get_asset(request, mutexed_tasks.clone()).await.unwrap();
+    let response_value = setup.das_api.get_asset(request).await.unwrap();
     let asset: Asset =
         serde_json::from_value::<Asset>(response_value.clone()).expect("Cannot parse 'Asset'.");
 

--- a/integrity_verification/src/main.rs
+++ b/integrity_verification/src/main.rs
@@ -48,7 +48,7 @@ async fn main() {
     start_metrics(metrics.registry, Some(config.metrics_port)).await;
 
     let mut tasks = JoinSet::new();
-    let cancel_token = CancellationToken::new();
+    let cancellation_token = CancellationToken::new();
     match config.test_source_mode {
         TestSourceMode::File => {
             let diff_checker = DiffChecker::new(
@@ -73,7 +73,7 @@ async fn main() {
                 config.run_assets_tests,
                 diff_checker,
                 metrics.integrity_verification_metrics.clone(),
-                cancel_token.clone(),
+                cancellation_token.clone(),
             )
             .await;
         },
@@ -107,15 +107,13 @@ async fn main() {
                 config.run_assets_tests,
                 diff_checker,
                 metrics.integrity_verification_metrics.clone(),
-                cancel_token.clone(),
+                cancellation_token.clone(),
             )
             .await;
         },
     };
 
-    usecase::graceful_stop::listen_shutdown().await;
-    cancel_token.cancel();
-    usecase::graceful_stop::graceful_stop(&mut tasks).await;
+    usecase::graceful_stop::graceful_shutdown(cancellation_token).await;
 }
 
 macro_rules! spawn_test {

--- a/interface/Cargo.toml
+++ b/interface/Cargo.toml
@@ -22,5 +22,6 @@ anchor-lang = { workspace = true }
 serde_json = { workspace = true }
 serde_derive = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 jsonrpc-core = { workspace = true }
 bubblegum-batch-sdk = { workspace = true }

--- a/interface/src/fork_cleaner.rs
+++ b/interface/src/fork_cleaner.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use async_trait::async_trait;
 use entities::models::{ClItem, ForkedItem, LeafSignatureAllData};
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
-use tokio::sync::broadcast::Receiver;
+use tokio_util::sync::CancellationToken;
 
 #[async_trait]
 pub trait CompressedTreeChangesManager {
@@ -16,6 +16,6 @@ pub trait CompressedTreeChangesManager {
 
 #[async_trait]
 pub trait ForkChecker {
-    fn get_all_non_forked_slots(&self, rx: Receiver<()>) -> HashSet<u64>;
+    fn get_all_non_forked_slots(&self, cancellation_token: CancellationToken) -> HashSet<u64>;
     fn last_slot_for_check(&self) -> u64;
 }

--- a/nft_ingester/benches/ingester_benchmark.rs
+++ b/nft_ingester/benches/ingester_benchmark.rs
@@ -70,7 +70,6 @@ fn ingest_benchmark(c: &mut Criterion) {
     let red_metrics = Arc::new(RequestErrorDurationMetrics::new());
     let transactions_storage = Storage::open(
         &format!("{}{}", tx_storage_dir.path().to_str().unwrap(), "/test_rocks"),
-        mutexed_tasks.clone(),
         red_metrics,
         MigrationState::Last,
     )

--- a/nft_ingester/benches/integrated_benchmark.rs
+++ b/nft_ingester/benches/integrated_benchmark.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use criterion::{criterion_group, criterion_main, Criterion};
 use entities::api_req_params::SearchAssets;
 use metrics_utils::ApiMetricsConfig;
-use nft_ingester::{api::middleware::JsonDownloaderMiddleware, index_syncronizer::Synchronizer};
+use nft_ingester::{api::middleware::JsonDownloaderMiddleware, index_synchronizer::Synchronizer};
 use rocks_db::storage_traits::AssetIndexReader;
 use setup::TestEnvironment;
 use testcontainers::clients::Cli;

--- a/nft_ingester/benches/synchronizer_benchmark.rs
+++ b/nft_ingester/benches/synchronizer_benchmark.rs
@@ -21,7 +21,7 @@ async fn bench_synchronize(env: Arc<TestEnvironment<'_>>, batch_size: usize) {
         .await
         .unwrap();
     let metrics = Arc::new(SynchronizerMetricsConfig::new());
-    let syncronizer = nft_ingester::index_syncronizer::Synchronizer::new(
+    let synchronizer = nft_ingester::index_synchronizer::Synchronizer::new(
         env.rocks_env.storage.clone(),
         env.pg_env.client.clone(),
         env.pg_env.client.clone(),
@@ -33,14 +33,14 @@ async fn bench_synchronize(env: Arc<TestEnvironment<'_>>, batch_size: usize) {
     );
 
     let (_, rx) = tokio::sync::broadcast::channel::<()>(1);
-    syncronizer.synchronize_asset_indexes(&rx, 0).await.unwrap();
+    synchronizer.synchronize_asset_indexes(&rx, 0).await.unwrap();
 }
 
 fn sync_benchmark(c: &mut Criterion) {
     let cli: Cli = Cli::default();
     let rt = tokio::runtime::Runtime::new().unwrap();
     let (env, _generated_assets) = rt.block_on(setup_environment(&cli));
-    let mut group = c.benchmark_group("Syncronizer Group");
+    let mut group = c.benchmark_group("Synchronizer Group");
     group.sample_size(10);
     group.measurement_time(std::time::Duration::from_secs(60));
     let env = Arc::new(env);

--- a/nft_ingester/src/api/backfilling_state_consistency.rs
+++ b/nft_ingester/src/api/backfilling_state_consistency.rs
@@ -49,7 +49,11 @@ impl BackfillingStateConsistencyChecker {
                     //     Ordering::Relaxed,
                     // );
                     //
-                    tokio::time::sleep(Duration::from_secs(CATCH_UP_SEQUENCES_TIMEOUT_SEC)).await;
+                    cancellation_token
+                        .run_until_cancelled(tokio::time::sleep(Duration::from_secs(
+                            CATCH_UP_SEQUENCES_TIMEOUT_SEC,
+                        )))
+                        .await;
                 }
             });
         }

--- a/nft_ingester/src/api/backfilling_state_consistency.rs
+++ b/nft_ingester/src/api/backfilling_state_consistency.rs
@@ -10,11 +10,7 @@ use entities::enums::{AssetType, ASSET_TYPES};
 use interface::consistency_check::ConsistencyChecker;
 use jsonrpc_core::Call;
 use rocks_db::Storage;
-use tokio::{
-    sync::Mutex,
-    task::{JoinError, JoinSet},
-};
-use tracing::info;
+use tokio_util::sync::CancellationToken;
 
 use crate::api::synchronization_state_consistency::CATCH_UP_SEQUENCES_TIMEOUT_SEC;
 
@@ -33,36 +29,29 @@ impl BackfillingStateConsistencyChecker {
 
     pub(crate) async fn run(
         &self,
-        tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
-        rx: tokio::sync::broadcast::Receiver<()>,
+        cancellation_token: CancellationToken,
         rocks_db: Arc<Storage>,
         _consistence_backfilling_slots_threshold: u64,
     ) {
         for asset_type in ASSET_TYPES {
             let _rocks_db = rocks_db.clone();
-            let mut rx = rx.resubscribe();
             let _overwhelm_backfill_gap = match asset_type {
                 AssetType::NonFungible => self.overwhelm_nft_backfill_gap.clone(),
                 AssetType::Fungible => self.overwhelm_fungible_backfill_gap.clone(),
             };
-            tasks.lock().await.spawn(async move {
-            while rx.is_empty() {
-                // TODO: refactor this to use parameter from storage and last slot from slot storage
-                // overwhelm_backfill_gap.store(
-                //     rocks_db.bubblegum_slots.iter_start().count().saturating_add(rocks_db.ingestable_slots.iter_start().count())
-                //         >= consistence_backfilling_slots_threshold as usize,
-                //     Ordering::Relaxed,
-                // );
-                tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_secs(CATCH_UP_SEQUENCES_TIMEOUT_SEC)) => {},
-                    _ = rx.recv() => {
-                        info!("Received stop signal, stopping BackfillingStateConsistencyChecker...");
-                        return Ok(());
-                    }
+            let cancellation_token = cancellation_token.child_token();
+            usecase::executor::spawn(async move {
+                while !cancellation_token.is_cancelled() {
+                    // TODO: refactor this to use parameter from storage and last slot from slot storage
+                    // overwhelm_backfill_gap.store(
+                    //     rocks_db.bubblegum_slots.iter_start().count().saturating_add(rocks_db.ingestable_slots.iter_start().count())
+                    //         >= consistence_backfilling_slots_threshold as usize,
+                    //     Ordering::Relaxed,
+                    // );
+                    //
+                    tokio::time::sleep(Duration::from_secs(CATCH_UP_SEQUENCES_TIMEOUT_SEC)).await;
                 }
-            }
-            Ok(())
-        });
+            });
         }
     }
 }

--- a/nft_ingester/src/api/builder.rs
+++ b/nft_ingester/src/api/builder.rs
@@ -8,10 +8,6 @@ use entities::api_req_params::{
 use interface::consistency_check::ConsistencyChecker;
 use jsonrpc_core::{types::params::Params, MetaIoHandler};
 use rocks_db::Storage;
-use tokio::{
-    sync::Mutex,
-    task::{JoinError, JoinSet},
-};
 use usecase::proofs::MaybeProofChecker;
 
 use crate::{
@@ -36,7 +32,6 @@ impl RpcApiBuilder {
             Storage,
         >,
         consistency_checkers: Vec<Arc<dyn ConsistencyChecker>>,
-        tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
     ) -> Result<MetaIoHandler<RpcMetaMiddleware, RpcMetaMiddleware>, DasApiError> {
         let mut module = MetaIoHandler::<RpcMetaMiddleware, RpcMetaMiddleware>::new(
             Default::default(),
@@ -59,15 +54,13 @@ impl RpcApiBuilder {
         module.add_alias("getAssetProof", "get_asset_proof");
 
         let cloned_api = api.clone();
-        let cloned_tasks = tasks.clone();
         module.add_method("get_asset", move |rpc_params: Params| {
             let api = cloned_api.clone();
-            let tasks = cloned_tasks.clone();
             async move {
                 match rpc_params.clone().parse::<GetAsset>() {
-                    Ok(payload) => api.get_asset(payload, tasks).await.map_err(Into::into),
+                    Ok(payload) => api.get_asset(payload).await.map_err(Into::into),
                     Err(_) => api
-                        .get_asset(rpc_params.parse::<GetAssetV0>()?.into(), tasks)
+                        .get_asset(rpc_params.parse::<GetAssetV0>()?.into())
                         .await
                         .map_err(Into::into),
                 }
@@ -76,20 +69,13 @@ impl RpcApiBuilder {
         module.add_alias("getAsset", "get_asset");
 
         let cloned_api = api.clone();
-        let cloned_tasks = tasks.clone();
         module.add_method("get_assets_by_owner", move |rpc_params: Params| {
             let api = cloned_api.clone();
-            let tasks = cloned_tasks.clone();
             async move {
                 match rpc_params.clone().parse::<GetAssetsByOwner>() {
-                    Ok(payload) => {
-                        api.get_assets_by_owner(payload, tasks).await.map_err(Into::into)
-                    },
+                    Ok(payload) => api.get_assets_by_owner(payload).await.map_err(Into::into),
                     Err(_) => api
-                        .get_assets_by_owner(
-                            rpc_params.parse::<GetAssetsByOwnerV0>()?.into(),
-                            tasks,
-                        )
+                        .get_assets_by_owner(rpc_params.parse::<GetAssetsByOwnerV0>()?.into())
                         .await
                         .map_err(Into::into),
                 }
@@ -98,20 +84,13 @@ impl RpcApiBuilder {
         module.add_alias("getAssetsByOwner", "get_assets_by_owner");
 
         let cloned_api = api.clone();
-        let cloned_tasks = tasks.clone();
         module.add_method("get_assets_by_creator", move |rpc_params: Params| {
             let api = cloned_api.clone();
-            let tasks = cloned_tasks.clone();
             async move {
                 match rpc_params.clone().parse::<GetAssetsByCreator>() {
-                    Ok(payload) => {
-                        api.get_assets_by_creator(payload, tasks).await.map_err(Into::into)
-                    },
+                    Ok(payload) => api.get_assets_by_creator(payload).await.map_err(Into::into),
                     Err(_) => api
-                        .get_assets_by_creator(
-                            rpc_params.parse::<GetAssetsByCreatorV0>()?.into(),
-                            tasks,
-                        )
+                        .get_assets_by_creator(rpc_params.parse::<GetAssetsByCreatorV0>()?.into())
                         .await
                         .map_err(Into::into),
                 }
@@ -120,19 +99,14 @@ impl RpcApiBuilder {
         module.add_alias("getAssetsByCreator", "get_assets_by_creator");
 
         let cloned_api = api.clone();
-        let cloned_tasks = tasks.clone();
         module.add_method("get_assets_by_authority", move |rpc_params: Params| {
             let api = cloned_api.clone();
-            let tasks = cloned_tasks.clone();
             async move {
                 match rpc_params.clone().parse::<GetAssetsByAuthority>() {
-                    Ok(payload) => {
-                        api.get_assets_by_authority(payload, tasks).await.map_err(Into::into)
-                    },
+                    Ok(payload) => api.get_assets_by_authority(payload).await.map_err(Into::into),
                     Err(_) => api
                         .get_assets_by_authority(
                             rpc_params.parse::<GetAssetsByAuthorityV0>()?.into(),
-                            tasks,
                         )
                         .await
                         .map_err(Into::into),
@@ -142,20 +116,13 @@ impl RpcApiBuilder {
         module.add_alias("getAssetsByAuthority", "get_assets_by_authority");
 
         let cloned_api = api.clone();
-        let cloned_tasks = tasks.clone();
         module.add_method("get_assets_by_group", move |rpc_params: Params| {
             let api = cloned_api.clone();
-            let tasks = cloned_tasks.clone();
             async move {
                 match rpc_params.clone().parse::<GetAssetsByGroup>() {
-                    Ok(payload) => {
-                        api.get_assets_by_group(payload, tasks).await.map_err(Into::into)
-                    },
+                    Ok(payload) => api.get_assets_by_group(payload).await.map_err(Into::into),
                     Err(_) => api
-                        .get_assets_by_group(
-                            rpc_params.parse::<GetAssetsByGroupV0>()?.into(),
-                            tasks,
-                        )
+                        .get_assets_by_group(rpc_params.parse::<GetAssetsByGroupV0>()?.into())
                         .await
                         .map_err(Into::into),
                 }
@@ -164,15 +131,13 @@ impl RpcApiBuilder {
         module.add_alias("getAssetsByGroup", "get_assets_by_group");
 
         let cloned_api = api.clone();
-        let cloned_tasks = tasks.clone();
         module.add_method("get_asset_batch", move |rpc_params: Params| {
             let api = cloned_api.clone();
-            let tasks = cloned_tasks.clone();
             async move {
                 match rpc_params.clone().parse::<GetAssetBatch>() {
-                    Ok(payload) => api.get_asset_batch(payload, tasks).await.map_err(Into::into),
+                    Ok(payload) => api.get_asset_batch(payload).await.map_err(Into::into),
                     Err(_) => api
-                        .get_asset_batch(rpc_params.parse::<GetAssetBatchV0>()?.into(), tasks)
+                        .get_asset_batch(rpc_params.parse::<GetAssetBatchV0>()?.into())
                         .await
                         .map_err(Into::into),
                 }
@@ -199,15 +164,13 @@ impl RpcApiBuilder {
         module.add_alias("getGrouping", "get_grouping");
 
         let cloned_api = api.clone();
-        let cloned_tasks = tasks.clone();
         module.add_method("search_assets", move |rpc_params: Params| {
             let api = cloned_api.clone();
-            let tasks = cloned_tasks.clone();
             async move {
                 match rpc_params.clone().parse::<SearchAssets>() {
-                    Ok(payload) => api.search_assets(payload, tasks).await.map_err(Into::into),
+                    Ok(payload) => api.search_assets(payload).await.map_err(Into::into),
                     Err(_) => api
-                        .search_assets(rpc_params.parse::<SearchAssetsV0>()?.into(), tasks)
+                        .search_assets(rpc_params.parse::<SearchAssetsV0>()?.into())
                         .await
                         .map_err(Into::into),
                 }

--- a/nft_ingester/src/api/dapi/change_logs.rs
+++ b/nft_ingester/src/api/dapi/change_logs.rs
@@ -275,7 +275,7 @@ fn get_asset_proof(
         let metrics = metrics.clone();
         let cloned_checker = proof_checker.clone();
         let asset_id = *asset_id;
-        tokio::spawn(async move {
+        usecase::executor::spawn(async move {
             match cloned_checker
                 .check_proof(tree_id, initial_proofs, leaf_data.nonce as u32, lf.to_bytes())
                 .await

--- a/nft_ingester/src/api/dapi/get_asset.rs
+++ b/nft_ingester/src/api/dapi/get_asset.rs
@@ -9,10 +9,6 @@ use interface::{
 use metrics_utils::ApiMetricsConfig;
 use rocks_db::{errors::StorageError, Storage};
 use solana_sdk::pubkey::Pubkey;
-use tokio::{
-    sync::Mutex,
-    task::{JoinError, JoinSet},
-};
 
 use super::asset_preview::populate_previews_slice;
 use crate::api::dapi::{asset, rpc_asset_convertors::asset_to_rpc, rpc_asset_models::Asset};
@@ -30,7 +26,6 @@ pub async fn get_asset<
     json_downloader: Option<Arc<JD>>,
     json_persister: Option<Arc<JP>>,
     max_json_to_download: usize,
-    tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
     storage_service_base_path: Option<String>,
     token_price_fetcher: Arc<TPF>,
     metrics: Arc<ApiMetricsConfig>,
@@ -43,7 +38,6 @@ pub async fn get_asset<
         json_downloader,
         json_persister,
         max_json_to_download,
-        tasks,
         &None,
         token_price_fetcher,
         metrics,

--- a/nft_ingester/src/api/dapi/get_asset_batch.rs
+++ b/nft_ingester/src/api/dapi/get_asset_batch.rs
@@ -9,10 +9,6 @@ use interface::{
 use metrics_utils::ApiMetricsConfig;
 use rocks_db::{errors::StorageError, Storage};
 use solana_sdk::pubkey::Pubkey;
-use tokio::{
-    sync::Mutex,
-    task::{JoinError, JoinSet},
-};
 
 use super::asset_preview::populate_previews_opt;
 use crate::api::dapi::{asset, rpc_asset_convertors::asset_to_rpc, rpc_asset_models::Asset};
@@ -30,7 +26,6 @@ pub async fn get_asset_batch<
     json_downloader: Option<Arc<JD>>,
     json_persister: Option<Arc<JP>>,
     max_json_to_download: usize,
-    tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
     storage_service_base_path: Option<String>,
     token_price_fetcher: Arc<TPF>,
     metrics: Arc<ApiMetricsConfig>,
@@ -43,7 +38,6 @@ pub async fn get_asset_batch<
         json_downloader,
         json_persister,
         max_json_to_download,
-        tasks,
         &None,
         token_price_fetcher,
         metrics,

--- a/nft_ingester/src/api/dapi/search_assets.rs
+++ b/nft_ingester/src/api/dapi/search_assets.rs
@@ -13,10 +13,6 @@ use interface::{
 use metrics_utils::ApiMetricsConfig;
 use rocks_db::{errors::StorageError, Storage};
 use solana_sdk::pubkey::Pubkey;
-use tokio::{
-    sync::Mutex,
-    task::{JoinError, JoinSet},
-};
 use tracing::error;
 
 use super::asset_preview::populate_previews;
@@ -47,7 +43,6 @@ pub async fn search_assets<
     json_downloader: Option<Arc<JD>>,
     json_persister: Option<Arc<JP>>,
     max_json_to_download: usize,
-    tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
     account_balance_getter: Arc<impl AccountBalanceGetter>,
     storage_service_base_path: Option<String>,
     token_price_fetcher: Arc<TPF>,
@@ -74,7 +69,6 @@ pub async fn search_assets<
             json_downloader,
             json_persister,
             max_json_to_download,
-            tasks,
             token_price_fetcher.clone(),
             metrics,
             tree_gaps_checker,
@@ -121,7 +115,6 @@ async fn fetch_assets<
     json_downloader: Option<Arc<JD>>,
     json_persister: Option<Arc<JP>>,
     max_json_to_download: usize,
-    tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>,
     token_price_fetcher: Arc<TPF>,
     metrics: Arc<ApiMetricsConfig>,
     tree_gaps_checker: &Option<Arc<PPC>>,
@@ -181,7 +174,6 @@ async fn fetch_assets<
         json_downloader,
         json_persister,
         max_json_to_download,
-        tasks,
         &owner_address,
         token_price_fetcher,
         metrics,

--- a/nft_ingester/src/bin/api/main.rs
+++ b/nft_ingester/src/bin/api/main.rs
@@ -232,7 +232,7 @@ pub async fn main() -> Result<(), IngesterError> {
         }
     });
 
-    if let Err(_) = stop_handle.await {
+    if stop_handle.await.is_err() {
         error!("Error joining graceful shutdown!");
     }
     Ok(())

--- a/nft_ingester/src/bin/backfill/main.rs
+++ b/nft_ingester/src/bin/backfill/main.rs
@@ -62,16 +62,12 @@ async fn main() {
         Storage::open_readonly_with_cfs_only_db(&args.source_db_path, SlotStorage::cf_names())
             .expect("Failed to open source RocksDB");
     let red_metrics = Arc::new(RequestErrorDurationMetrics::new());
+    let cancellation_token = CancellationToken::new();
 
     // Open target RocksDB
     let target_db = Arc::new(
-        Storage::open(
-            &args.target_db_path,
-            Arc::new(tokio::sync::Mutex::new(tokio::task::JoinSet::new())),
-            red_metrics.clone(),
-            MigrationState::Last,
-        )
-        .expect("Failed to open target RocksDB"),
+        Storage::open(&args.target_db_path, red_metrics.clone(), MigrationState::Last)
+            .expect("Failed to open target RocksDB"),
     );
 
     // Initialize the DirectBlockParser
@@ -93,23 +89,22 @@ async fn main() {
     let slots_processed = Arc::new(AtomicU64::new(0));
     let rate = Arc::new(Mutex::new(0.0));
 
-    // Spawn a task to handle graceful shutdown on Ctrl+C
-    let shutdown_token = CancellationToken::new();
-    let shutdown_token_clone = shutdown_token.clone();
-
-    let slot_sender_clone = slot_sender.clone();
-    tokio::spawn(async move {
-        // Wait for Ctrl+C signal
-        match tokio::signal::ctrl_c().await {
-            Ok(()) => {
-                info!("Received Ctrl+C, shutting down gracefully...");
-                shutdown_token_clone.cancel();
-                // Close the channel to signal workers to stop
-                slot_sender_clone.close();
-            },
-            Err(err) => {
-                error!("Unable to listen for shutdown signal: {}", err);
-            },
+    usecase::executor::spawn({
+        let cancellation_token = cancellation_token.clone();
+        let slot_sender = slot_sender.clone();
+        async move {
+            // Wait for Ctrl+C signal
+            match tokio::signal::ctrl_c().await {
+                Ok(()) => {
+                    info!("Received Ctrl+C, shutting down gracefully...");
+                    cancellation_token.cancel();
+                    // Close the channel to signal workers to stop
+                    slot_sender.close();
+                },
+                Err(err) => {
+                    error!("Unable to listen for shutdown signal: {}", err);
+                },
+            }
         }
     });
 
@@ -197,82 +192,85 @@ async fn main() {
         let progress_bar = progress_bar.clone();
         let slots_processed = slots_processed.clone();
         let rate = rate.clone();
-        let shutdown_token = shutdown_token.clone();
 
         let slot_receiver = slot_receiver.clone();
 
-        let handle = tokio::spawn(async move {
-            while let Ok((slot, raw_block_data)) = slot_receiver.recv().await {
-                if shutdown_token.is_cancelled() {
-                    break;
+        let handle = tokio::task::spawn({
+            let cancellation_token = cancellation_token.child_token();
+            async move {
+                while let Ok((slot, raw_block_data)) = slot_receiver.recv().await {
+                    if cancellation_token.is_cancelled() {
+                        break;
+                    }
+
+                    // Process the slot
+                    let raw_block: RawBlock = match RawBlock::decode(&raw_block_data) {
+                        Ok(rb) => rb,
+                        Err(e) => {
+                            error!("Failed to decode the value for slot {}: {}", slot, e);
+                            continue;
+                        },
+                    };
+
+                    if let Err(e) = consumer.consume_block(slot, raw_block.block).await {
+                        error!("Error processing slot {}: {}", slot, e);
+                    }
+
+                    // Increment slots_processed
+                    let current_slots_processed =
+                        slots_processed.fetch_add(1, Ordering::Relaxed) + 1;
+
+                    // Update progress bar position and message
+                    progress_bar.inc(1);
+
+                    let current_rate = {
+                        let rate_guard = rate.lock().unwrap();
+                        *rate_guard
+                    };
+                    progress_bar.set_message(format!(
+                        "Slots Processed: {} Current Slot: {} Rate: {:.2}/s",
+                        current_slots_processed, slot, current_rate
+                    ));
                 }
-
-                // Process the slot
-                let raw_block: RawBlock = match RawBlock::decode(&raw_block_data) {
-                    Ok(rb) => rb,
-                    Err(e) => {
-                        error!("Failed to decode the value for slot {}: {}", slot, e);
-                        continue;
-                    },
-                };
-
-                if let Err(e) = consumer.consume_block(slot, raw_block.block).await {
-                    error!("Error processing slot {}: {}", slot, e);
-                }
-
-                // Increment slots_processed
-                let current_slots_processed = slots_processed.fetch_add(1, Ordering::Relaxed) + 1;
-
-                // Update progress bar position and message
-                progress_bar.inc(1);
-
-                let current_rate = {
-                    let rate_guard = rate.lock().unwrap();
-                    *rate_guard
-                };
-                progress_bar.set_message(format!(
-                    "Slots Processed: {} Current Slot: {} Rate: {:.2}/s",
-                    current_slots_processed, slot, current_rate
-                ));
             }
         });
 
         worker_handles.push(handle);
     }
 
-    // Spawn a task to update the rate periodically
-    let slots_processed_clone = slots_processed.clone();
-    let rate_clone = rate.clone();
-    let shutdown_token_clone = shutdown_token.clone();
+    usecase::executor::spawn({
+        let cancellation_token = cancellation_token.clone();
+        let slots_processed = slots_processed.clone();
+        let rate = rate.clone();
+        async move {
+            let mut last_time = std::time::Instant::now();
+            let mut last_count = slots_processed.load(Ordering::Relaxed);
 
-    tokio::spawn(async move {
-        let mut last_time = std::time::Instant::now();
-        let mut last_count = slots_processed_clone.load(Ordering::Relaxed);
+            loop {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
 
-        loop {
-            tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                if cancellation_token.is_cancelled() {
+                    break;
+                }
 
-            if shutdown_token_clone.is_cancelled() {
-                break;
+                let current_time = std::time::Instant::now();
+                let current_count = slots_processed.load(Ordering::Relaxed);
+
+                let elapsed = current_time.duration_since(last_time).as_secs_f64();
+                let count = current_count - last_count;
+
+                let current_rate = if elapsed > 0.0 { (count as f64) / elapsed } else { 0.0 };
+
+                // Update rate
+                {
+                    let mut rate_guard = rate.lock().unwrap();
+                    *rate_guard = current_rate;
+                }
+
+                // Update for next iteration
+                last_time = current_time;
+                last_count = current_count;
             }
-
-            let current_time = std::time::Instant::now();
-            let current_count = slots_processed_clone.load(Ordering::Relaxed);
-
-            let elapsed = current_time.duration_since(last_time).as_secs_f64();
-            let count = current_count - last_count;
-
-            let current_rate = if elapsed > 0.0 { (count as f64) / elapsed } else { 0.0 };
-
-            // Update rate
-            {
-                let mut rate_guard = rate_clone.lock().unwrap();
-                *rate_guard = current_rate;
-            }
-
-            // Update for next iteration
-            last_time = current_time;
-            last_count = current_count;
         }
     });
 
@@ -283,7 +281,7 @@ async fn main() {
             slots_to_process,
             source_db,
             slot_sender.clone(),
-            shutdown_token.clone(),
+            cancellation_token.child_token(),
         )
         .await;
     } else {
@@ -291,7 +289,7 @@ async fn main() {
         send_all_slots_to_workers(
             source_db,
             slot_sender.clone(),
-            shutdown_token.clone(),
+            cancellation_token.child_token(),
             args.first_slot,
             args.last_slot,
         )
@@ -306,6 +304,7 @@ async fn main() {
         let _ = handle.await;
     }
 
+    usecase::graceful_stop::graceful_shutdown(cancellation_token).await;
     progress_bar.finish_with_message("Processing complete");
 }
 
@@ -314,12 +313,12 @@ async fn send_slots_to_workers(
     slots_to_process: Vec<u64>,
     source_db: rocksdb::DB,
     slot_sender: async_channel::Sender<(u64, Vec<u8>)>,
-    shutdown_token: CancellationToken,
+    cancellation_token: CancellationToken,
 ) {
     let cf_handle = source_db.cf_handle(RawBlock::NAME).unwrap();
 
     for slot in slots_to_process {
-        if shutdown_token.is_cancelled() {
+        if cancellation_token.is_cancelled() {
             info!("Shutdown signal received. Stopping the submission of new slots.");
             break;
         }
@@ -347,7 +346,7 @@ async fn send_slots_to_workers(
 async fn send_all_slots_to_workers(
     source_db: rocksdb::DB,
     slot_sender: async_channel::Sender<(u64, Vec<u8>)>,
-    shutdown_token: CancellationToken,
+    cancellation_token: CancellationToken,
     first_slot: Option<u64>,
     last_slot: Option<u64>,
 ) {
@@ -367,7 +366,7 @@ async fn send_all_slots_to_workers(
 
     // Send slots to the channel
     while iter.valid() {
-        if shutdown_token.is_cancelled() {
+        if cancellation_token.is_cancelled() {
             info!("Shutdown signal received. Stopping the submission of new slots.");
             break;
         }

--- a/nft_ingester/src/bin/backfill/main.rs
+++ b/nft_ingester/src/bin/backfill/main.rs
@@ -310,7 +310,7 @@ async fn main() {
         let _ = handle.await;
     }
 
-    if let Err(_) = stop_handle.await {
+    if stop_handle.await.is_err() {
         error!("Error joining graceful shutdown!");
     }
     progress_bar.finish_with_message("Processing complete");

--- a/nft_ingester/src/bin/burnt_assets_ingester/main.rs
+++ b/nft_ingester/src/bin/burnt_assets_ingester/main.rs
@@ -294,13 +294,8 @@ async fn main() {
     // Open target RocksDB
     let red_metrics = Arc::new(RequestErrorDurationMetrics::new());
     let target_db = Arc::new(
-        Storage::open(
-            &args.target_db_path,
-            Arc::new(tokio::sync::Mutex::new(tokio::task::JoinSet::new())),
-            red_metrics.clone(),
-            MigrationState::Last,
-        )
-        .expect("Failed to open target RocksDB"),
+        Storage::open(&args.target_db_path, red_metrics.clone(), MigrationState::Last)
+            .expect("Failed to open target RocksDB"),
     );
 
     // Initialize metrics

--- a/nft_ingester/src/bin/dumper/main.rs
+++ b/nft_ingester/src/bin/dumper/main.rs
@@ -2,16 +2,14 @@ use std::{fs::File, path::PathBuf, sync::Arc};
 
 use clap::{command, Parser};
 use metrics_utils::SynchronizerMetricsConfig;
-use nft_ingester::{error::IngesterError, index_syncronizer::shard_pubkeys, init::graceful_stop};
+use nft_ingester::{error::IngesterError, index_synchronizer::shard_pubkeys};
 use rocks_db::{
     migrator::MigrationState,
     storage_traits::{AssetUpdateIndexStorage, Dumper},
     Storage,
 };
-use tokio::{
-    sync::{broadcast, Mutex},
-    task::JoinSet,
-};
+use tokio::task::JoinSet;
+use tokio_util::sync::CancellationToken;
 
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
@@ -63,31 +61,17 @@ pub async fn main() -> Result<(), IngesterError> {
     let metrics = Arc::new(SynchronizerMetricsConfig::new());
     let red_metrics = Arc::new(metrics_utils::red::RequestErrorDurationMetrics::new());
 
-    let tasks = JoinSet::new();
-    let mutexed_tasks = Arc::new(Mutex::new(tasks));
-
+    let cancellation_token = CancellationToken::new();
     let rocks_storage = Arc::new(
         Storage::open_secondary(
             &args.source_path,
             &secondary_storage_path,
-            mutexed_tasks.clone(),
             red_metrics.clone(),
             MigrationState::Last,
         )
         .unwrap(),
     );
 
-    let cloned_tasks = mutexed_tasks.clone();
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-    mutexed_tasks.lock().await.spawn(async move {
-        // --stop
-        #[cfg(not(feature = "profiling"))]
-        graceful_stop(cloned_tasks, shutdown_tx, None).await;
-        #[cfg(feature = "profiling")]
-        graceful_stop(cloned_tasks, shutdown_tx, None, None, None, "").await;
-
-        Ok(())
-    });
     if let Err(e) = rocks_storage.db.try_catch_up_with_primary() {
         tracing::error!("Sync rocksdb error: {}", e);
     }
@@ -154,22 +138,24 @@ pub async fn main() -> Result<(), IngesterError> {
 
         let start = *start;
         let end = *end;
-        let shutdown_rx = shutdown_rx.resubscribe();
         let metrics = metrics.clone();
         let rocks_storage = rocks_storage.clone();
-        tasks.spawn_blocking(move || {
-            rocks_storage.dump_nft_csv(
-                assets_file,
-                creators_file,
-                authority_file,
-                metadata_file,
-                args.buffer_capacity,
-                args.limit,
-                Some(start),
-                Some(end),
-                &shutdown_rx,
-                metrics,
-            )
+        tasks.spawn_blocking({
+            let cancellation_token = cancellation_token.child_token();
+            move || {
+                rocks_storage.dump_nft_csv(
+                    assets_file,
+                    creators_file,
+                    authority_file,
+                    metadata_file,
+                    args.buffer_capacity,
+                    args.limit,
+                    Some(start),
+                    Some(end),
+                    cancellation_token,
+                    metrics,
+                )
+            }
         });
     }
 
@@ -190,18 +176,20 @@ pub async fn main() -> Result<(), IngesterError> {
 
         let start = *start;
         let end = *end;
-        let shutdown_rx = shutdown_rx.resubscribe();
         let metrics = metrics.clone();
         let rocks_storage = rocks_storage.clone();
-        fungible_tasks.spawn_blocking(move || {
-            rocks_storage.dump_fungible_csv(
-                (fungible_tokens_file, fungible_tokens_path),
-                args.buffer_capacity,
-                Some(start),
-                Some(end),
-                &shutdown_rx,
-                metrics,
-            )
+        fungible_tasks.spawn_blocking({
+            let cancellation_token = cancellation_token.child_token();
+            move || {
+                rocks_storage.dump_fungible_csv(
+                    (fungible_tokens_file, fungible_tokens_path),
+                    args.buffer_capacity,
+                    Some(start),
+                    Some(end),
+                    cancellation_token,
+                    metrics,
+                )
+            }
         });
     }
 
@@ -222,6 +210,10 @@ pub async fn main() -> Result<(), IngesterError> {
         task.map_err(|e| e.to_string())?.map_err(|e| e.to_string())?;
     }
     tracing::info!("Dumping fungible tokens done");
+    #[cfg(not(feature = "profiling"))]
+    usecase::graceful_stop::graceful_shutdown(cancellation_token).await;
+    #[cfg(feature = "profiling")]
+    nft_ingester::init::graceful_stop(cancellation_token, None, None, "").await;
     let keys_file = File::create(base_path.join("keys.csv")).expect("should create keys file");
     Storage::dump_last_keys(keys_file, last_known_key, last_known_fungible_key)?;
     Ok(())

--- a/nft_ingester/src/bin/dumper/main.rs
+++ b/nft_ingester/src/bin/dumper/main.rs
@@ -222,7 +222,7 @@ pub async fn main() -> Result<(), IngesterError> {
     tracing::info!("Dumping fungible tokens done");
     let keys_file = File::create(base_path.join("keys.csv")).expect("should create keys file");
     Storage::dump_last_keys(keys_file, last_known_key, last_known_fungible_key)?;
-    if let Err(_) = stop_handle.await {
+    if stop_handle.await.is_err() {
         error!("Error joining graceful shutdown!");
     }
     Ok(())

--- a/nft_ingester/src/bin/ingester/main.rs
+++ b/nft_ingester/src/bin/ingester/main.rs
@@ -14,7 +14,6 @@ use arweave_rs::{consts::ARWEAVE_BASE_URL, Arweave};
 use backfill_rpc::rpc::BackfillRPC;
 use clap::Parser;
 use entities::enums::ASSET_TYPES;
-use futures::FutureExt;
 use grpc::{
     asseturls::asset_url_service_server::AssetUrlServiceServer,
     asseturls_impl::AssetUrlServiceImpl, client::Client,
@@ -37,7 +36,7 @@ use nft_ingester::{
     consts::RAYDIUM_API_HOST,
     error::IngesterError,
     gapfiller::{process_asset_details_stream_wrapper, run_sequence_consistent_gapfiller},
-    init::{graceful_stop, init_index_storage_with_migration, init_primary_storage},
+    init::{init_index_storage_with_migration, init_primary_storage},
     json_worker,
     json_worker::JsonWorker,
     processors::{
@@ -57,11 +56,6 @@ use postgre_client::PG_MIGRATIONS_PATH;
 use pprof::ProfilerGuardBuilder;
 use rocks_db::{storage_traits::AssetSlotStorage, SlotStorage};
 use solana_client::nonblocking::rpc_client::RpcClient;
-use tokio::{
-    sync::{broadcast, Mutex},
-    task::JoinSet,
-    time::sleep as tokio_sleep,
-};
 use tokio_util::sync::CancellationToken;
 use tonic::transport::Server;
 use tracing::{error, info, warn};
@@ -114,6 +108,8 @@ pub async fn main() -> Result<(), IngesterError> {
             .expect("Failed to build 'ProfilerGuardBuilder'!")
     });
 
+    let cancellation_token = CancellationToken::new();
+
     // try to restore rocksDB first
     if args.is_restore_rocks_db {
         restore_rocksdb(
@@ -131,9 +127,6 @@ pub async fn main() -> Result<(), IngesterError> {
         .await?;
     }
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
     info!("Init primary storage...");
     let primary_rocks_storage = Arc::new(
         init_primary_storage(
@@ -141,7 +134,6 @@ pub async fn main() -> Result<(), IngesterError> {
             args.enable_rocks_migration.unwrap_or(false),
             &args.rocks_migration_storage_path,
             &metrics_state,
-            mutexed_tasks.clone(),
         )
         .await?,
     );
@@ -173,28 +165,25 @@ pub async fn main() -> Result<(), IngesterError> {
         Some(metrics_state.red_metrics.clone()),
     ));
     let tpf = token_price_fetcher.clone();
-    let tasks_clone = mutexed_tasks.clone();
 
-    tasks_clone.lock().await.spawn(async move {
+    cancellation_token.run_until_cancelled(async move {
         if let Err(e) = tpf.warmup().await {
             warn!(error = %e, "Failed to warm up Raydium token price fetcher, cache is empty: {:?}", e);
         }
         let (symbol_cache_size, _) = tpf.get_cache_sizes();
         info!(%symbol_cache_size, "Warmed up Raydium token price fetcher with {} symbols", symbol_cache_size);
-        Ok(())
-    });
+    }).await;
     let well_known_fungible_accounts =
         token_price_fetcher.get_all_token_symbols().await.unwrap_or_else(|_| HashMap::new());
 
     info!("Init Redis ....");
-    let cloned_rx = shutdown_rx.resubscribe();
     let message_config = MessengerConfig {
         messenger_type: MessengerType::Redis,
         connection_config: args.redis_connection_config.clone(),
     };
 
     let ack_channel =
-        create_ack_channel(cloned_rx, message_config.clone(), mutexed_tasks.clone()).await;
+        create_ack_channel(message_config.clone(), cancellation_token.child_token()).await;
 
     for index in 0..args.redis_accounts_parsing_workers {
         let account_consumer_worker_name = Uuid::new_v4().to_string();
@@ -226,8 +215,7 @@ pub async fn main() -> Result<(), IngesterError> {
         );
 
         run_accounts_processor(
-            shutdown_rx.resubscribe(),
-            mutexed_tasks.clone(),
+            cancellation_token.child_token(),
             redis_receiver,
             primary_rocks_storage.clone(),
             args.account_processor_buffer_size,
@@ -236,11 +224,9 @@ pub async fn main() -> Result<(), IngesterError> {
             Some(metrics_state.message_process_metrics.clone()),
             index_pg_storage.clone(),
             rpc_client.clone(),
-            mutexed_tasks.clone(),
             Some(account_consumer_worker_name.clone()),
             well_known_fungible_accounts.clone(),
-        )
-        .await;
+        );
     }
 
     for index in 0..args.redis_transactions_parsing_workers {
@@ -272,13 +258,11 @@ pub async fn main() -> Result<(), IngesterError> {
         );
 
         run_transaction_processor(
-            shutdown_rx.resubscribe(),
-            mutexed_tasks.clone(),
+            cancellation_token.child_token(),
             redis_receiver,
             geyser_bubblegum_updates_processor.clone(),
             Some(metrics_state.message_process_metrics.clone()),
-        )
-        .await;
+        );
     }
 
     info!("MessageSource Redis FINISH");
@@ -288,12 +272,11 @@ pub async fn main() -> Result<(), IngesterError> {
     let first_processed_slot = Arc::new(AtomicU64::new(0));
     let first_processed_slot_clone = first_processed_slot.clone();
     let cloned_rocks_storage = primary_rocks_storage.clone();
-    let cloned_rx = shutdown_rx.resubscribe();
-    let cloned_tx = shutdown_tx.clone();
 
-    mutexed_tasks.lock().await.spawn(receive_last_saved_slot(
-        cloned_rx,
-        cloned_tx,
+    usecase::executor::spawn(receive_last_saved_slot(
+        // NOTE: the clone here is important to bubble up the cancellation
+        // from this function to other child tokens.
+        cancellation_token.clone(),
         cloned_rocks_storage,
         first_processed_slot_clone,
         last_saved_slot,
@@ -319,18 +302,19 @@ pub async fn main() -> Result<(), IngesterError> {
                 .map_err(|e| error!("GRPC Client new: {e}"))
                 .expect("Failed to create GRPC Client");
 
-        while first_processed_slot.load(Ordering::Relaxed) == 0 && shutdown_rx.is_empty() {
-            tokio_sleep(Duration::from_millis(100)).await
+        while first_processed_slot.load(Ordering::Relaxed) == 0
+            && !cancellation_token.is_cancelled()
+        {
+            tokio::time::sleep(Duration::from_millis(100)).await
         }
 
         let cloned_rocks_storage = primary_rocks_storage.clone();
-        if shutdown_rx.is_empty() {
+        if !cancellation_token.is_cancelled() {
             let gaped_data_client_clone = gaped_data_client.clone();
 
             let first_processed_slot_value = first_processed_slot.load(Ordering::Relaxed);
-            let cloned_rx = shutdown_rx.resubscribe();
-            mutexed_tasks.lock().await.spawn(process_asset_details_stream_wrapper(
-                cloned_rx,
+            usecase::executor::spawn(process_asset_details_stream_wrapper(
+                cancellation_token.child_token(),
                 cloned_rocks_storage,
                 last_saved_slot,
                 first_processed_slot_value,
@@ -339,9 +323,8 @@ pub async fn main() -> Result<(), IngesterError> {
             ));
 
             let cloned_rocks_storage = primary_rocks_storage.clone();
-            let cloned_rx = shutdown_rx.resubscribe();
-            mutexed_tasks.lock().await.spawn(process_asset_details_stream_wrapper(
-                cloned_rx,
+            usecase::executor::spawn(process_asset_details_stream_wrapper(
+                cancellation_token.child_token(),
                 cloned_rocks_storage,
                 last_saved_slot,
                 first_processed_slot_value,
@@ -359,10 +342,9 @@ pub async fn main() -> Result<(), IngesterError> {
         args.check_proofs_probability,
         args.check_proofs_commitment,
     )));
-    let cloned_rx = shutdown_rx.resubscribe();
     let file_storage_path = args.file_storage_path_container.clone();
 
-    if args.run_api.unwrap_or(false) {
+    if args.run_api.unwrap_or_default() {
         info!("Starting API (Ingester)...");
         let middleware_json_downloader = args
             .json_middleware_config
@@ -382,49 +364,44 @@ pub async fn main() -> Result<(), IngesterError> {
 
         let cloned_index_storage = index_pg_storage.clone();
 
-        mutexed_tasks.lock().await.spawn(async move {
-            match start_api(
-                cloned_index_storage,
-                cloned_rocks_storage.clone(),
-                cloned_rx,
-                cloned_api_metrics,
-                args.server_port,
-                proof_checker,
-                tree_gaps_checker,
-                args.max_page_limit,
-                middleware_json_downloader.clone(),
-                middleware_json_downloader,
-                args.json_middleware_config,
-                tasks_clone,
-                &args.archives_dir,
-                args.consistence_synchronization_api_threshold,
-                args.consistence_backfilling_slots_threshold,
-                args.batch_mint_service_port,
-                args.file_storage_path_container.as_str(),
-                account_balance_getter,
-                args.storage_service_base_url,
-                args.native_mint_pubkey,
-                token_price_fetcher,
-            )
-            .await
-            {
-                Ok(_) => Ok(()),
-                Err(e) => {
-                    error!("Start API: {}", e);
-                    Ok(())
-                },
+        usecase::executor::spawn({
+            let cancellation_token = cancellation_token.child_token();
+            async move {
+                start_api(
+                    cloned_index_storage,
+                    cloned_rocks_storage.clone(),
+                    cancellation_token,
+                    cloned_api_metrics,
+                    args.server_port,
+                    proof_checker,
+                    tree_gaps_checker,
+                    args.max_page_limit,
+                    middleware_json_downloader.clone(),
+                    middleware_json_downloader,
+                    args.json_middleware_config,
+                    &args.archives_dir,
+                    args.consistence_synchronization_api_threshold,
+                    args.consistence_backfilling_slots_threshold,
+                    args.batch_mint_service_port,
+                    args.file_storage_path_container.as_str(),
+                    account_balance_getter,
+                    args.storage_service_base_url,
+                    args.native_mint_pubkey,
+                    token_price_fetcher,
+                )
+                .await
+                .inspect_err(|e| error!("Start API: {}", e))
             }
         });
     }
 
-    let cloned_rx = shutdown_rx.resubscribe();
-    let cloned_jp = json_processor.clone();
-    mutexed_tasks.lock().await.spawn(json_worker::run(cloned_jp, cloned_rx).map(|_| Ok(())));
-
-    let shutdown_token = CancellationToken::new();
+    usecase::executor::spawn(json_worker::run(
+        json_processor.clone(),
+        cancellation_token.child_token(),
+    ));
 
     // Backfiller
-    if args.run_backfiller.unwrap_or(false) {
+    if args.run_backfiller.unwrap_or_default() {
         info!("Start backfiller...");
 
         let backfill_bubblegum_updates_processor = Arc::new(BubblegumTxProcessor::new(
@@ -441,7 +418,6 @@ pub async fn main() -> Result<(), IngesterError> {
                     .clone()
                     .expect("slots_db_path is required for SlotStorage"),
                 args.rocks_secondary_slots_db_path.clone(),
-                mutexed_tasks.clone(),
                 metrics_state.red_metrics.clone(),
             )
             .expect("Failed to open slot storage"),
@@ -459,7 +435,7 @@ pub async fn main() -> Result<(), IngesterError> {
             .await,
         );
 
-        if args.run_bubblegum_backfiller.unwrap_or(false) {
+        if args.run_bubblegum_backfiller.unwrap_or_default() {
             info!("Runing Bubblegum backfiller (ingester)...");
 
             if args.should_reingest {
@@ -476,20 +452,21 @@ pub async fn main() -> Result<(), IngesterError> {
                 primary_rocks_storage.clone(),
                 metrics_state.backfiller_metrics.clone(),
             ));
-            let shutdown_token = shutdown_token.clone();
             let db = primary_rocks_storage.clone();
             let metrics: Arc<BackfillerMetricsConfig> = metrics_state.backfiller_metrics.clone();
             let slot_db = slot_db.clone();
-            mutexed_tasks.lock().await.spawn(async move {
-                nft_ingester::backfiller::run_backfill_slots(
-                    shutdown_token,
-                    db,
-                    slot_db,
-                    consumer,
-                    metrics,
-                )
-                .await;
-                Ok(())
+            usecase::executor::spawn({
+                let cancellation_token = cancellation_token.child_token();
+                async move {
+                    nft_ingester::backfiller::run_backfill_slots(
+                        cancellation_token,
+                        db,
+                        slot_db,
+                        consumer,
+                        metrics,
+                    )
+                    .await;
+                }
             });
         }
 
@@ -508,9 +485,8 @@ pub async fn main() -> Result<(), IngesterError> {
                 metrics_state.sequence_consistent_gapfill_metrics.clone(),
                 backfiller_source.clone(),
                 direct_block_parser,
-                shutdown_rx.resubscribe(),
+                cancellation_token.child_token(),
                 rpc_backfiller.clone(),
-                mutexed_tasks.clone(),
                 args.sequence_consistent_checker_wait_period_sec,
             )
             .await;
@@ -527,19 +503,19 @@ pub async fn main() -> Result<(), IngesterError> {
         let asset_url_serv = AssetUrlServiceImpl::new(primary_rocks_storage.clone());
         let addr = format!("0.0.0.0:{}", args.peer_grpc_port).parse()?;
         // Spawn the gRPC server task and add to JoinSet
-        let mut rx = shutdown_rx.resubscribe();
 
-        mutexed_tasks.lock().await.spawn(async move {
-            if let Err(e) = Server::builder()
-                .add_service(GapFillerServiceServer::new(serv))
-                .add_service(AssetUrlServiceServer::new(asset_url_serv))
-                .serve_with_shutdown(addr, rx.recv().map(|_| ()))
-                .await
-            {
-                error!("Server error: {}", e);
+        usecase::executor::spawn({
+            let cancellation_token = cancellation_token.child_token();
+            async move {
+                if let Err(e) = Server::builder()
+                    .add_service(GapFillerServiceServer::new(serv))
+                    .add_service(AssetUrlServiceServer::new(asset_url_serv))
+                    .serve_with_shutdown(addr, cancellation_token.cancelled())
+                    .await
+                {
+                    error!("Server error: {}", e);
+                }
             }
-
-            Ok(())
         });
 
         let rocks_clone = primary_rocks_storage.clone();
@@ -549,42 +525,52 @@ pub async fn main() -> Result<(), IngesterError> {
             tx_ingester.clone(),
             metrics_state.rpc_backfiller_metrics.clone(),
         );
-        let cloned_rx = shutdown_rx.resubscribe();
         let metrics_clone = metrics_state.rpc_backfiller_metrics.clone();
 
-        mutexed_tasks.lock().await.spawn(async move {
-            let program_id = mpl_bubblegum::programs::MPL_BUBBLEGUM_ID;
-            while cloned_rx.is_empty() {
-                match signature_fetcher
-                    .fetch_signatures(program_id, args.rpc_retry_interval_millis)
-                    .await
-                {
-                    Ok(_) => {
-                        metrics_clone
-                            .inc_run_fetch_signatures("fetch_signatures", MetricStatus::SUCCESS);
-                        info!(
-                            "signatures sync finished successfully for program_id: {}",
-                            program_id
-                        );
-                    },
-                    Err(e) => {
-                        metrics_clone
-                            .inc_run_fetch_signatures("fetch_signatures", MetricStatus::FAILURE);
-                        error!("signatures sync failed: {:?} for program_id: {}", e, program_id);
-                    },
+        usecase::executor::spawn({
+            let cancellation_token = cancellation_token.child_token();
+            async move {
+                let program_id = mpl_bubblegum::programs::MPL_BUBBLEGUM_ID;
+                while !cancellation_token.is_cancelled() {
+                    match signature_fetcher
+                        .fetch_signatures(program_id, args.rpc_retry_interval_millis)
+                        .await
+                    {
+                        Ok(_) => {
+                            metrics_clone.inc_run_fetch_signatures(
+                                "fetch_signatures",
+                                MetricStatus::SUCCESS,
+                            );
+                            info!(
+                                "signatures sync finished successfully for program_id: {}",
+                                program_id
+                            );
+                        },
+                        Err(e) => {
+                            metrics_clone.inc_run_fetch_signatures(
+                                "fetch_signatures",
+                                MetricStatus::FAILURE,
+                            );
+                            error!(
+                                "signatures sync failed: {:?} for program_id: {}",
+                                e, program_id
+                            );
+                        },
+                    }
+
+                    tokio::time::sleep(Duration::from_secs(60)).await;
                 }
-
-                tokio_sleep(Duration::from_secs(60)).await;
             }
-
-            Ok(())
         });
     }
 
-    Scheduler::run_in_background(Scheduler::new(
-        primary_rocks_storage.clone(),
-        Some(well_known_fungible_accounts.keys().cloned().collect()),
-    ))
+    Scheduler::run_in_background(
+        Scheduler::new(
+            primary_rocks_storage.clone(),
+            Some(well_known_fungible_accounts.keys().cloned().collect()),
+        ),
+        cancellation_token.child_token(),
+    )
     .await;
 
     if let Ok(arweave) = Arweave::from_keypair_path(
@@ -602,9 +588,11 @@ pub async fn main() -> Result<(), IngesterError> {
             file_storage_path,
             metrics_state.batch_mint_processor_metrics.clone(),
         ));
-        let rx = shutdown_rx.resubscribe();
         let processor_clone = batch_mint_processor.clone();
-        mutexed_tasks.lock().await.spawn(process_batch_mints(processor_clone, rx));
+        usecase::executor::spawn(process_batch_mints(
+            processor_clone,
+            cancellation_token.child_token(),
+        ));
     }
 
     let batch_mint_persister = BatchMintPersister::new(
@@ -613,10 +601,12 @@ pub async fn main() -> Result<(), IngesterError> {
         metrics_state.batch_mint_persisting_metrics.clone(),
     );
 
-    let rx = shutdown_rx.resubscribe();
-    mutexed_tasks.lock().await.spawn(async move {
-        info!("Start batch_mint persister...");
-        batch_mint_persister.persist_batch_mints(rx).await
+    usecase::executor::spawn({
+        let cancellation_token = cancellation_token.child_token();
+        async move {
+            info!("Start batch_mint persister...");
+            batch_mint_persister.persist_batch_mints(cancellation_token).await
+        }
     });
 
     // clean indexes
@@ -624,28 +614,28 @@ pub async fn main() -> Result<(), IngesterError> {
         info!("Start cleaning index {:?}", asset_type);
 
         let primary_rocks_storage = primary_rocks_storage.clone();
-        let mut rx = shutdown_rx.resubscribe();
         let index_pg_storage = index_pg_storage.clone();
-        mutexed_tasks.lock().await.spawn(async move {
-            let index_pg_storage = index_pg_storage.clone();
-            tokio::select! {
-                _ = rx.recv() => {}
-                _ = async move {
-                    loop {
-                        match clean_syncronized_idxs(index_pg_storage.clone(), primary_rocks_storage.clone(), asset_type).await {
-                            Ok(_) => {
-                                info!("Cleaned synchronized indexes for {:?}", asset_type);
+        usecase::executor::spawn({
+            let cancellation_token = cancellation_token.child_token();
+            async move {
+                let index_pg_storage = index_pg_storage.clone();
+                tokio::select! {
+                    _ = cancellation_token.cancelled() => {}
+                    _ = async move {
+                        loop {
+                            match clean_syncronized_idxs(index_pg_storage.clone(), primary_rocks_storage.clone(), asset_type).await {
+                                Ok(_) => {
+                                    info!("Cleaned synchronized indexes for {:?}", asset_type);
+                                }
+                                Err(e) => {
+                                    error!("Failed to clean synchronized indexes for {:?} with error {}", asset_type, e);
+                                }
                             }
-                            Err(e) => {
-                                error!("Failed to clean synchronized indexes for {:?} with error {}", asset_type, e);
-                            }
+                            tokio::time::sleep(Duration::from_secs(SECONDS_TO_RETRY_IDXS_CLEANUP)).await;
                         }
-                        tokio::time::sleep(Duration::from_secs(SECONDS_TO_RETRY_IDXS_CLEANUP)).await;
-                    }
-                } => {}
+                    } => {}
+                }
             }
-
-            Ok(())
         });
     }
 
@@ -653,13 +643,11 @@ pub async fn main() -> Result<(), IngesterError> {
 
     // --stop
     #[cfg(not(feature = "profiling"))]
-    graceful_stop(mutexed_tasks, shutdown_tx, Some(shutdown_token)).await;
+    usecase::graceful_stop::graceful_shutdown(cancellation_token).await;
 
     #[cfg(feature = "profiling")]
-    graceful_stop(
-        mutexed_tasks,
-        shutdown_tx,
-        Some(shutdown_token),
+    nft_ingester::init::graceful_stop(
+        cancellation_token,
         guard,
         args.profiling_file_path_container,
         &args.heap_path,

--- a/nft_ingester/src/bin/migrator/main.rs
+++ b/nft_ingester/src/bin/migrator/main.rs
@@ -90,7 +90,7 @@ pub async fn main() -> Result<(), IngesterError> {
         }
     });
 
-    if let Err(_) = stop_handle.await {
+    if stop_handle.await.is_err() {
         error!("Error joining graceful shutdown!");
     }
 

--- a/nft_ingester/src/bin/migrator/main.rs
+++ b/nft_ingester/src/bin/migrator/main.rs
@@ -9,7 +9,6 @@ use metrics_utils::{
 use nft_ingester::{
     config::{init_logger, JsonMigratorMode, MigratorClapArgs},
     error::IngesterError,
-    init::graceful_stop,
 };
 use postgre_client::PgClient;
 use rocks_db::{
@@ -19,10 +18,8 @@ use rocks_db::{
     migrator::MigrationState,
     Storage,
 };
-use tokio::{
-    sync::{broadcast, broadcast::Receiver, Mutex},
-    task::{JoinError, JoinSet},
-};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
 
 pub const DEFAULT_MIN_POSTGRES_CONNECTIONS: u32 = 100;
@@ -52,12 +49,11 @@ pub async fn main() -> Result<(), IngesterError> {
 
     start_metrics(metrics_state.registry, args.metrics_port).await;
 
-    let mutexed_tasks = Arc::new(Mutex::new(JoinSet::new()));
     let red_metrics = Arc::new(RequestErrorDurationMetrics::new());
+    let cancellation_token = CancellationToken::new();
 
     let storage = Storage::open(
         args.rocks_json_target_db.clone(),
-        mutexed_tasks.clone(),
         red_metrics.clone(),
         MigrationState::Last,
     )?;
@@ -65,7 +61,6 @@ pub async fn main() -> Result<(), IngesterError> {
     let target_storage = Arc::new(storage);
     let source_storage = Storage::open(
         args.rocks_json_source_db.clone(),
-        mutexed_tasks.clone(),
         red_metrics.clone(),
         MigrationState::Last,
     )?;
@@ -79,20 +74,17 @@ pub async fn main() -> Result<(), IngesterError> {
         args.migrator_mode,
     );
 
-    let cloned_tasks = mutexed_tasks.clone();
-
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
-    let cloned_rx = shutdown_rx.resubscribe();
-    mutexed_tasks.lock().await.spawn(async move {
-        json_migrator.run(cloned_rx, cloned_tasks).await;
-        Ok(())
+    usecase::executor::spawn({
+        let cancellation_token = cancellation_token.child_token();
+        async move {
+            json_migrator.run(cancellation_token).await;
+        }
     });
 
     #[cfg(not(feature = "profiling"))]
-    graceful_stop(mutexed_tasks, shutdown_tx, None).await;
+    usecase::graceful_stop::graceful_shutdown(cancellation_token).await;
     #[cfg(feature = "profiling")]
-    graceful_stop(mutexed_tasks, shutdown_tx, None, None, None, "").await;
+    nft_ingester::init::graceful_stop(cancellation_token, None, None, "").await;
 
     Ok(())
 }
@@ -116,40 +108,40 @@ impl JsonMigrator {
         Self { database_pool, source_rocks_db, target_rocks_db, metrics, migrator_mode }
     }
 
-    pub async fn run(&self, rx: Receiver<()>, tasks: Arc<Mutex<JoinSet<Result<(), JoinError>>>>) {
+    pub async fn run(&self, cancellation_token: CancellationToken) {
         match self.migrator_mode {
             JsonMigratorMode::Full => {
                 info!("Launch JSON migrator in full mode");
 
                 info!("Start migrate JSONs...");
-                self.migrate_jsons(rx.resubscribe()).await;
+                self.migrate_jsons(cancellation_token.child_token()).await;
 
                 info!("JSONs are migrated. Start setting tasks...");
-                self.set_tasks(rx.resubscribe(), tasks).await;
+                self.set_tasks(cancellation_token).await;
                 info!("Tasks are set!");
             },
             JsonMigratorMode::JsonsOnly => {
                 info!("Launch JSON migrator in jsons only mode");
 
                 info!("Start migrate JSONs...");
-                self.migrate_jsons(rx.resubscribe()).await;
+                self.migrate_jsons(cancellation_token).await;
                 info!("JSONs are migrated!");
             },
             JsonMigratorMode::TasksOnly => {
                 info!("Launch JSON migrator in tasks only mode");
 
                 info!("Start set tasks...");
-                self.set_tasks(rx.resubscribe(), tasks).await;
+                self.set_tasks(cancellation_token).await;
                 info!("Tasks are set!");
             },
         }
     }
 
-    pub async fn migrate_jsons(&self, rx: Receiver<()>) {
+    pub async fn migrate_jsons(&self, cancellation_token: CancellationToken) {
         let all_available_jsons = self.source_rocks_db.asset_offchain_data.iter_end();
 
         for json in all_available_jsons {
-            if !rx.is_empty() {
+            if cancellation_token.is_cancelled() {
                 info!("JSON migrator is stopped");
                 break;
             }
@@ -189,11 +181,7 @@ impl JsonMigrator {
         }
     }
 
-    pub async fn set_tasks(
-        &self,
-        rx: Receiver<()>,
-        tasks: Arc<Mutex<JoinSet<core::result::Result<(), JoinError>>>>,
-    ) {
+    pub async fn set_tasks(&self, cancellation_token: CancellationToken) {
         let mut assets_iter = self.target_rocks_db.db.raw_iterator_cf(
             &self.target_rocks_db.db.cf_handle(AssetCompleteDetails::NAME).unwrap(),
         );
@@ -206,61 +194,62 @@ impl JsonMigrator {
 
         let tasks_batch_to_insert = 1000;
 
-        let cloned_rx = rx.resubscribe();
-
-        tasks.lock().await.spawn(async move {
-            loop {
-                if !cloned_rx.is_empty() {
-                    info!("Worker to clean tasks buffer is stopped");
-                    break;
-                }
-
-                let mut tasks_buffer = cloned_tasks_buffer.lock().await;
-
-                if tasks_buffer.is_empty() {
-                    drop(tasks_buffer);
-                    tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
-                    continue;
-                }
-
-                let end_point = {
-                    if tasks_buffer.len() < tasks_batch_to_insert {
-                        tasks_buffer.len()
-                    } else {
-                        tasks_batch_to_insert
+        usecase::executor::spawn({
+            let cancellation_token = cancellation_token.child_token();
+            async move {
+                loop {
+                    if cancellation_token.is_cancelled() {
+                        info!("Worker to clean tasks buffer is stopped");
+                        break;
                     }
-                };
 
-                let mut tasks_to_insert = tasks_buffer.drain(0..end_point).collect::<Vec<Task>>();
+                    let mut tasks_buffer = cloned_tasks_buffer.lock().await;
 
-                drop(tasks_buffer);
+                    if tasks_buffer.is_empty() {
+                        drop(tasks_buffer);
+                        tokio::time::sleep(tokio::time::Duration::from_secs(10)).await;
+                        continue;
+                    }
 
-                let res = cloned_pg_client.insert_json_download_tasks(&mut tasks_to_insert).await;
-                match res {
-                    Ok(_) => {
-                        cloned_metrics.inc_tasks_set(
-                            "tasks_set",
-                            MetricStatus::SUCCESS,
-                            tasks_to_insert.len() as u64,
-                        );
-                    },
-                    Err(e) => {
-                        cloned_metrics.inc_tasks_set(
-                            "tasks_set",
-                            MetricStatus::FAILURE,
-                            tasks_to_insert.len() as u64,
-                        );
-                        error!("insert_tasks: {}", e)
-                    },
+                    let end_point = {
+                        if tasks_buffer.len() < tasks_batch_to_insert {
+                            tasks_buffer.len()
+                        } else {
+                            tasks_batch_to_insert
+                        }
+                    };
+
+                    let mut tasks_to_insert =
+                        tasks_buffer.drain(0..end_point).collect::<Vec<Task>>();
+
+                    drop(tasks_buffer);
+
+                    let res =
+                        cloned_pg_client.insert_json_download_tasks(&mut tasks_to_insert).await;
+                    match res {
+                        Ok(_) => {
+                            cloned_metrics.inc_tasks_set(
+                                "tasks_set",
+                                MetricStatus::SUCCESS,
+                                tasks_to_insert.len() as u64,
+                            );
+                        },
+                        Err(e) => {
+                            cloned_metrics.inc_tasks_set(
+                                "tasks_set",
+                                MetricStatus::FAILURE,
+                                tasks_to_insert.len() as u64,
+                            );
+                            error!("insert_tasks: {}", e)
+                        },
+                    }
                 }
             }
-
-            Ok(())
         });
 
         assets_iter.seek_to_first();
         while assets_iter.valid() {
-            if !rx.is_empty() {
+            if cancellation_token.is_cancelled() {
                 info!("Setting tasks for JSONs is stopped");
                 break;
             }

--- a/nft_ingester/src/bin/rocksdb_backup/main.rs
+++ b/nft_ingester/src/bin/rocksdb_backup/main.rs
@@ -9,7 +9,6 @@ use rocks_db::{
     migrator::MigrationState,
     Storage,
 };
-use tokio::{sync::Mutex, task::JoinSet};
 use tracing::{debug, info};
 
 #[tokio::main(flavor = "multi_thread")]
@@ -23,13 +22,9 @@ async fn main() -> Result<(), RocksDbBackupServiceError> {
     let red_metrics = Arc::new(metrics_utils::red::RequestErrorDurationMetrics::new());
     red_metrics.register(&mut registry);
 
-    let tasks = JoinSet::new();
-    let mutexed_tasks = Arc::new(Mutex::new(tasks));
-
     let storage = Storage::open_secondary(
         &args.rocks_db_path,
         &args.rocks_db_secondary_path,
-        mutexed_tasks.clone(),
         red_metrics.clone(),
         MigrationState::Last,
     )

--- a/nft_ingester/src/bin/slot_persister/main.rs
+++ b/nft_ingester/src/bin/slot_persister/main.rs
@@ -14,10 +14,7 @@ use nft_ingester::{
     inmemory_slots_dumper::InMemorySlotsDumper,
 };
 use rocks_db::{column::TypedColumn, SlotStorage};
-use tokio::{
-    sync::{broadcast, Semaphore},
-    task::JoinSet,
-};
+use tokio::{sync::Semaphore, task::JoinSet};
 use tokio_retry::{strategy::ExponentialBackoff, RetryIf};
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, info, warn};
@@ -151,14 +148,11 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
     metrics_state.register_metrics();
 
     start_metrics(metrics_state.registry, Some(args.metrics_port)).await;
+    let cancellation_token = CancellationToken::new();
     // Open target RocksDB
     let target_db = Arc::new(
-        SlotStorage::open(
-            &args.target_db_path,
-            Arc::new(tokio::sync::Mutex::new(tokio::task::JoinSet::new())),
-            metrics_state.red_metrics.clone(),
-        )
-        .expect("Failed to open target RocksDB"),
+        SlotStorage::open(&args.target_db_path, metrics_state.red_metrics.clone())
+            .expect("Failed to open target RocksDB"),
     );
 
     let last_persisted_slot = get_last_persisted_slot(target_db.clone());
@@ -173,22 +167,20 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         last_persisted_slot
     };
 
-    let shutdown_token = CancellationToken::new();
-    let shutdown_token_clone = shutdown_token.clone();
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-
     // Spawn a task to handle graceful shutdown on Ctrl+C
-    tokio::spawn(async move {
-        // Wait for Ctrl+C signal
-        match tokio::signal::ctrl_c().await {
-            Ok(()) => {
-                info!("Received Ctrl+C, shutting down gracefully...");
-                shutdown_token_clone.cancel();
-                shutdown_tx.send(()).unwrap();
-            },
-            Err(err) => {
-                error!("Unable to listen for shutdown signal: {}", err);
-            },
+    usecase::executor::spawn({
+        let cancellation_token = cancellation_token.clone();
+        async move {
+            // Wait for Ctrl+C signal
+            match tokio::signal::ctrl_c().await {
+                Ok(()) => {
+                    info!("Received Ctrl+C, shutting down gracefully...");
+                    cancellation_token.cancel();
+                },
+                Err(err) => {
+                    error!("Unable to listen for shutdown signal: {}", err);
+                },
+            }
         }
     });
 
@@ -242,13 +234,19 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         info!("Total slots to process: {}", provided_slots.len());
 
         // Proceed to process the provided slots
-        process_slots(provided_slots, backfill_source, target_db, &args, shutdown_token.clone())
-            .await;
+        process_slots(
+            provided_slots,
+            backfill_source,
+            target_db,
+            &args,
+            cancellation_token.child_token(),
+        )
+        .await;
         return Ok(()); // Exit after processing provided slots
     }
     let mut start_slot = start_slot;
     loop {
-        if shutdown_token.is_cancelled() {
+        if cancellation_token.is_cancelled() {
             info!("Shutdown signal received, exiting main loop...");
             break;
         }
@@ -265,7 +263,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         &blockbuster::programs::bubblegum::ID,
                         last_slot_to_check,
                         start_slot,
-                        &shutdown_rx,
+                        cancellation_token.child_token(),
                     )
                     .await;
                 if let Some(slot) = top_collected_slot {
@@ -286,7 +284,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
                     tokio::select! {
                         _ = sleep => {},
-                        _ = shutdown_token.cancelled() => {
+                        _ = cancellation_token.cancelled() => {
                             info!("Received shutdown signal, stopping loop...");
                             break;
                         },
@@ -299,7 +297,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     backfill_source.clone(),
                     target_db.clone(),
                     &args,
-                    shutdown_token.clone(),
+                    cancellation_token.child_token(),
                 )
                 .await;
             },
@@ -311,7 +309,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         let sleep = tokio::time::sleep(wait_period);
         tokio::select! {
             _ = sleep => {},
-            _ = shutdown_token.cancelled() => {
+            _ = cancellation_token.cancelled() => {
                 info!("Received shutdown signal, stopping loop...");
                 break;
             },
@@ -326,11 +324,11 @@ async fn process_slots(
     backfill_source: Arc<BackfillSource>,
     target_db: Arc<SlotStorage>,
     args: &Args,
-    shutdown_token: CancellationToken,
+    cancellation_token: CancellationToken,
 ) {
     // Process slots in batches
     for batch in slots.chunks(args.chunk_size) {
-        if shutdown_token.is_cancelled() {
+        if cancellation_token.is_cancelled() {
             info!("Shutdown signal received during batch processing, exiting...");
             break;
         }
@@ -344,7 +342,7 @@ async fn process_slots(
 
         // Retry loop for the batch
         loop {
-            if shutdown_token.is_cancelled() {
+            if cancellation_token.is_cancelled() {
                 info!("Shutdown signal received during batch processing, exiting...");
                 break;
             }
@@ -353,7 +351,7 @@ async fn process_slots(
 
             let backfill_source = backfill_source.clone();
             let semaphore = Arc::new(Semaphore::new(args.max_concurrency));
-            let shutdown_token = shutdown_token.clone();
+            let shutdown_token = cancellation_token.clone();
 
             match &*backfill_source {
                 // ------------------------------------------------------------------

--- a/nft_ingester/src/bin/slot_persister/main.rs
+++ b/nft_ingester/src/bin/slot_persister/main.rs
@@ -305,7 +305,7 @@ pub async fn main() -> Result<(), Box<dyn std::error::Error>> {
         };
     }
 
-    if let Err(_) = stop_handle.await {
+    if stop_handle.await.is_err() {
         error!("Error joining graceful shutdown!");
     }
     info!("Slot persister has stopped.");

--- a/nft_ingester/src/bin/synchronizer/main.rs
+++ b/nft_ingester/src/bin/synchronizer/main.rs
@@ -6,16 +6,13 @@ use metrics_utils::SynchronizerMetricsConfig;
 use nft_ingester::{
     config::{init_logger, SynchronizerClapArgs},
     error::IngesterError,
-    index_syncronizer::{SyncStatus, Synchronizer},
-    init::{graceful_stop, init_index_storage_with_migration},
+    index_synchronizer::{SyncStatus, Synchronizer},
+    init::init_index_storage_with_migration,
 };
 use postgre_client::PG_MIGRATIONS_PATH;
 use prometheus_client::registry::Registry;
 use rocks_db::{migrator::MigrationState, Storage};
-use tokio::{
-    sync::{broadcast, Mutex},
-    task::JoinSet,
-};
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "profiling")]
@@ -57,42 +54,17 @@ pub async fn main() -> Result<(), IngesterError> {
         .await?,
     );
 
-    let tasks = JoinSet::new();
-    let mutexed_tasks = Arc::new(Mutex::new(tasks));
+    let cancellation_token = CancellationToken::new();
 
     let storage = Storage::open_secondary(
         &args.rocks_db_path,
         &args.rocks_db_secondary_path,
-        mutexed_tasks.clone(),
         red_metrics.clone(),
         MigrationState::Last,
     )
     .unwrap();
 
     let rocks_storage = Arc::new(storage);
-    let cloned_tasks = mutexed_tasks.clone();
-    let (shutdown_tx, shutdown_rx) = broadcast::channel::<()>(1);
-    let shutdown_token = CancellationToken::new();
-    let shutdown_token_clone = shutdown_token.clone();
-
-    mutexed_tasks.lock().await.spawn(async move {
-        // --stop
-        #[cfg(not(feature = "profiling"))]
-        graceful_stop(cloned_tasks, shutdown_tx, Some(shutdown_token_clone)).await;
-
-        #[cfg(feature = "profiling")]
-        graceful_stop(
-            cloned_tasks,
-            shutdown_tx,
-            Some(shutdown_token_clone),
-            guard,
-            args.profiling_file_path_container,
-            &args.heap_path,
-        )
-        .await;
-
-        Ok(())
-    });
 
     let synchronizer = Arc::new(Synchronizer::new(
         rocks_storage.clone(),
@@ -110,46 +82,46 @@ pub async fn main() -> Result<(), IngesterError> {
     let mut sync_tasks = JoinSet::new();
     for asset_type in ASSET_TYPES {
         let synchronizer = synchronizer.clone();
-        let shutdown_rx = shutdown_rx.resubscribe();
-        let shutdown_token = shutdown_token.clone();
-        sync_tasks.spawn(async move {
-            if let Ok(SyncStatus::FullSyncRequired(_)) = synchronizer
-                .get_sync_state(args.dump_sync_threshold, asset_type)
-                .await
-            {
-                tracing::info!("Starting full sync for {:?}", asset_type);
-                let res = synchronizer.full_syncronize(&shutdown_rx, asset_type).await;
-                match res {
-                    Ok(_) => {
-                        tracing::info!("Full {:?} synchronization finished successfully", asset_type);
+        sync_tasks.spawn({
+            let cancellation_token = cancellation_token.child_token();
+            async move {
+                if let Ok(SyncStatus::FullSyncRequired(_)) = synchronizer
+                    .get_sync_state(args.dump_sync_threshold, asset_type)
+                    .await
+                {
+                    tracing::info!("Starting full sync for {:?}", asset_type);
+                    let res = synchronizer.full_syncronize(cancellation_token.child_token(), asset_type).await;
+                    match res {
+                        Ok(_) => {
+                            tracing::info!("Full {:?} synchronization finished successfully", asset_type);
+                        }
+                        Err(e) => {
+                            tracing::error!("Full {:?} synchronization failed: {:?}", asset_type, e);
+                        }
                     }
-                    Err(e) => {
-                        tracing::error!("Full {:?} synchronization failed: {:?}", asset_type, e);
+                }
+                while !cancellation_token.is_cancelled() {
+                    let result = synchronizer
+                        .synchronize_asset_indexes(asset_type, cancellation_token.child_token(), args.dump_sync_threshold)
+                        .await;
+
+                    match result {
+                        Ok(_) => {
+                            tracing::info!("{:?} Synchronization finished successfully", asset_type)
+                        }
+                        Err(e) => tracing::error!("{:?} Synchronization failed: {:?}", asset_type, e),
+                    }
+                    tokio::select! {
+                        _ = tokio::time::sleep(tokio::time::Duration::from_secs(
+                            args.timeout_between_syncs_sec,
+                        )) => {}
+                        _ = cancellation_token.cancelled() => {
+                            tracing::info!("Shutdown signal received, stopping {:?} synchronizer", asset_type);
+                            break;
+                        }
                     }
                 }
             }
-            while shutdown_rx.is_empty() {
-                let result = synchronizer
-                    .synchronize_asset_indexes(asset_type, &shutdown_rx, args.dump_sync_threshold)
-                    .await;
-
-                match result {
-                    Ok(_) => {
-                        tracing::info!("{:?} Synchronization finished successfully", asset_type)
-                    }
-                    Err(e) => tracing::error!("{:?} Synchronization failed: {:?}", asset_type, e),
-                }
-                tokio::select! {
-                    _ = tokio::time::sleep(tokio::time::Duration::from_secs(
-                        args.timeout_between_syncs_sec,
-                    )) => {}
-                    _ = shutdown_token.cancelled() => {
-                        tracing::info!("Shutdown signal received, stopping {:?} synchronizer", asset_type);
-                        break;
-                    }
-                }
-            }
-
         });
     }
     while let Some(task) = sync_tasks.join_next().await {
@@ -157,8 +129,18 @@ pub async fn main() -> Result<(), IngesterError> {
             IngesterError::UnrecoverableTaskError(format!("joining task failed: {}", e))
         })?;
     }
+    // --stop
+    #[cfg(not(feature = "profiling"))]
+    usecase::graceful_stop::graceful_shutdown(cancellation_token).await;
 
-    while (mutexed_tasks.lock().await.join_next().await).is_some() {}
+    #[cfg(feature = "profiling")]
+    nft_ingester::init::graceful_stop(
+        cancellation_token,
+        guard,
+        args.profiling_file_path_container,
+        &args.heap_path,
+    )
+    .await;
 
     Ok(())
 }

--- a/nft_ingester/src/bin/synchronizer_utils/main.rs
+++ b/nft_ingester/src/bin/synchronizer_utils/main.rs
@@ -13,7 +13,6 @@ use rocks_db::{
     Storage,
 };
 use solana_sdk::pubkey::Pubkey;
-use tokio::{sync::Mutex, task::JoinSet};
 use tracing::info;
 
 #[derive(Parser, Debug)]
@@ -48,14 +47,11 @@ pub async fn main() -> Result<(), IngesterError> {
 
     let tx_storage_dir = tempfile::TempDir::new().unwrap();
 
-    let tasks = JoinSet::new();
-    let mutexed_tasks = Arc::new(Mutex::new(tasks));
     let red_metrics = Arc::new(metrics_utils::red::RequestErrorDurationMetrics::new());
 
     let storage = Storage::open_secondary(
         &args.db_path,
         &tx_storage_dir.path().to_path_buf(),
-        mutexed_tasks.clone(),
         red_metrics.clone(),
         MigrationState::Last,
     )

--- a/nft_ingester/src/cleaners/fork_cleaner.rs
+++ b/nft_ingester/src/cleaners/fork_cleaner.rs
@@ -6,10 +6,10 @@ use metrics_utils::ForkCleanerMetricsConfig;
 use rocks_db::{SlotStorage, Storage};
 use solana_sdk::{pubkey::Pubkey, signature::Signature};
 use tokio::{
-    sync::broadcast::Receiver,
     task::JoinError,
     time::{sleep as tokio_sleep, Instant},
 };
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 const CI_ITEMS_DELETE_BATCH_SIZE: usize = 100;
@@ -18,18 +18,18 @@ const SLOT_CHECK_OFFSET: u64 = 1500;
 pub async fn run_fork_cleaner(
     fork_cleaner: ForkCleaner<Storage, SlotStorage>,
     metrics: Arc<ForkCleanerMetricsConfig>,
-    mut rx: Receiver<()>,
+    cancellation_token: CancellationToken,
     sequence_consistent_checker_wait_period_sec: u64,
 ) -> Result<(), JoinError> {
     info!("Start cleaning forks...");
     loop {
         let start = Instant::now();
-        fork_cleaner.clean_forks(rx.resubscribe()).await;
+        fork_cleaner.clean_forks(cancellation_token.child_token()).await;
         metrics.set_scans_latency(start.elapsed().as_secs_f64());
         metrics.inc_total_scans();
         tokio::select! {
             _ = tokio_sleep(Duration::from_secs(sequence_consistent_checker_wait_period_sec)) => {},
-            _ = rx.recv() => {
+            _ = cancellation_token.cancelled() => {
                 info!("Received stop signal, stopping cleaning forks!");
                 break;
             }
@@ -62,10 +62,11 @@ where
         Self { cl_items_manager, fork_checker, metrics }
     }
 
-    pub async fn clean_forks(&self, rx: Receiver<()>) {
+    pub async fn clean_forks(&self, cancellation_token: CancellationToken) {
         let last_slot_for_check =
             self.fork_checker.last_slot_for_check().saturating_sub(SLOT_CHECK_OFFSET);
-        let all_non_forked_slots = self.fork_checker.get_all_non_forked_slots(rx.resubscribe());
+        let all_non_forked_slots =
+            self.fork_checker.get_all_non_forked_slots(cancellation_token.child_token());
 
         let mut forked_slots = 0;
         let mut delete_items = Vec::new();
@@ -73,7 +74,7 @@ where
         // from this column data will be dropped by slot
         // if we have any update from forked slot we have to delete it
         for cl_item in self.cl_items_manager.cl_items_iter() {
-            if !rx.is_empty() {
+            if cancellation_token.is_cancelled() {
                 info!("Stop iteration over cl items iterator...");
                 return;
             }

--- a/nft_ingester/src/lib.rs
+++ b/nft_ingester/src/lib.rs
@@ -9,7 +9,7 @@ pub mod consts;
 pub mod error;
 pub mod flatbuffer_mapper;
 pub mod gapfiller;
-pub mod index_syncronizer;
+pub mod index_synchronizer;
 pub mod init;
 pub mod inmemory_slots_dumper;
 pub mod inscription_raw_parsing;

--- a/nft_ingester/src/processors/account_based/mpl_core_fee_indexing_processor.rs
+++ b/nft_ingester/src/processors/account_based/mpl_core_fee_indexing_processor.rs
@@ -9,11 +9,9 @@ use metrics_utils::IngesterMetricsConfig;
 use postgre_client::PgClient;
 use solana_client::nonblocking::rpc_client::RpcClient;
 use solana_program::{pubkey::Pubkey, rent::Rent, sysvar::rent};
-use tokio::{
-    sync::{broadcast::Receiver, Mutex, RwLock},
-    task::JoinSet,
-};
-use tracing::{error, info};
+use tokio::sync::RwLock;
+use tokio_util::sync::CancellationToken;
+use tracing::error;
 
 use crate::error::IngesterError;
 
@@ -26,7 +24,6 @@ pub struct MplCoreFeeProcessor {
     pub metrics: Arc<IngesterMetricsConfig>,
     rpc_client: Arc<RpcClient>,
     rent: Arc<RwLock<Rent>>,
-    join_set: Arc<Mutex<JoinSet<Result<(), tokio::task::JoinError>>>>,
 }
 
 impl MplCoreFeeProcessor {
@@ -34,35 +31,33 @@ impl MplCoreFeeProcessor {
         storage: Arc<PgClient>,
         metrics: Arc<IngesterMetricsConfig>,
         rpc_client: Arc<RpcClient>,
-        join_set: Arc<Mutex<JoinSet<Result<(), tokio::task::JoinError>>>>,
     ) -> Result<Self, IngesterError> {
         let rent_account = rpc_client.get_account(&rent::ID).await?;
         let rent: Rent = bincode::deserialize(&rent_account.data)?;
-        Ok(Self { storage, metrics, rpc_client, rent: Arc::new(RwLock::new(rent)), join_set })
+        Ok(Self { storage, metrics, rpc_client, rent: Arc::new(RwLock::new(rent)) })
     }
 
     // on-chain programs can fetch rent without RPC call
     // but off-chain indexer need to make such calls in order
     // to get actual rent data
-    pub async fn update_rent(&self, mut rx: Receiver<()>) {
+    pub fn update_rent(&self, cancellation_token: CancellationToken) {
         let rpc_client = self.rpc_client.clone();
         let rent = self.rent.clone();
-        self.join_set.lock().await.spawn(tokio::spawn(async move {
-            while rx.is_empty() {
-                if let Err(e) = Self::fetch_actual_rent(rpc_client.clone(), rent.clone()).await {
-                    error!("fetch_actual_rent: {}", e);
-                    tokio::time::sleep(Duration::from_secs(5)).await;
-                    continue;
-                }
+        usecase::executor::spawn(async move {
+            loop {
                 tokio::select! {
-                    _ = rx.recv() => {
-                        info!("Received stop signal, stopping update_rent...");
-                        return;
+                    _ = cancellation_token.cancelled() => { break; }
+                    result = Self::fetch_actual_rent(rpc_client.clone(), rent.clone()) => {
+                        if let Err(e) = result {
+                            error!("fetch_actual_rent: {}", e);
+                            tokio::time::sleep(Duration::from_secs(5)).await;
+                            continue;
+                        }
                     }
-                    _ = tokio::time::sleep(FETCH_RENT_INTERVAL) => {},
+                    _ = tokio::time::sleep(FETCH_RENT_INTERVAL) => {}
                 }
             }
-        }));
+        });
     }
 
     async fn fetch_actual_rent(

--- a/nft_ingester/src/processors/accounts_processor.rs
+++ b/nft_ingester/src/processors/accounts_processor.rs
@@ -165,7 +165,7 @@ impl<T: UnprocessedAccountsGetter> AccountsProcessor<T> {
         let mut interval = tokio::time::interval(FLUSH_INTERVAL);
         let mut batch_fill_instant = Instant::now();
 
-        while !cancellation_token.is_cancelled() {
+        loop {
             tokio::select! {
                 unprocessed_accounts = self.unprocessed_account_getter.next_accounts(accounts_batch_size) => {
                         let unprocessed_accounts = match unprocessed_accounts {

--- a/nft_ingester/src/scheduler.rs
+++ b/nft_ingester/src/scheduler.rs
@@ -62,10 +62,7 @@ impl Scheduler {
         cancellation_token: CancellationToken,
     ) {
         usecase::executor::spawn(async move {
-            tokio::select! {
-                _ = cancellation_token.cancelled() => {}
-                _ = scheduler.run() => {}
-            }
+            cancellation_token.run_until_cancelled(scheduler.run()).await;
         });
     }
 

--- a/nft_ingester/tests/api_tests.rs
+++ b/nft_ingester/tests/api_tests.rs
@@ -84,7 +84,7 @@ mod tests {
     use sqlx::QueryBuilder;
     use tempfile::TempDir;
     use testcontainers::clients::Cli;
-    use tokio::{sync::Mutex, task::JoinSet};
+    use tokio_util::sync::CancellationToken;
     use usecase::proofs::MaybeProofChecker;
 
     const SLOT_UPDATED: u64 = 100;
@@ -94,15 +94,13 @@ mod tests {
         26, 235, 59, 85, 152, 160, 240, 0, 0, 0, 0, 1,
     ]);
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_search_assets() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, generated_assets) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let limit = 10;
         let before: Option<String>;
         let after: Option<String>;
@@ -116,7 +114,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             assert!(res.is_object());
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             after = res_obj.cursor.clone();
@@ -147,7 +145,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             for i in 0..limit {
                 assert_eq!(
@@ -168,7 +166,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             for i in 0..limit {
                 assert_eq!(
@@ -189,7 +187,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert!(res_obj.items.is_empty(), "items should be empty");
         }
@@ -204,7 +202,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             for i in 0..limit {
                 assert_eq!(
@@ -225,7 +223,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert!(res_obj.items.is_empty(), "items should be empty");
         }
@@ -253,7 +251,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             for i in 0..limit {
                 assert_eq!(
@@ -275,7 +273,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert_eq!(res_obj.total, 1, "total should be 1");
             assert_eq!(res_obj.items.len(), 1, "items length should be 1");
@@ -297,7 +295,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert_eq!(res_obj.total, 1, "total should be 1");
             assert_eq!(res_obj.items.len(), 1, "items length should be 1");
@@ -319,7 +317,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             // calculate the number of assets with creator verified true
             let mut cnt = 0;
@@ -342,7 +340,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert_eq!(res_obj.total, 1, "total should be 1");
             assert_eq!(res_obj.items.len(), 1, "items length should be 1");
@@ -364,7 +362,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert_eq!(res_obj.total, 1, "total should be 1");
             assert_eq!(res_obj.items.len(), 1, "items length should be 1");
@@ -386,7 +384,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert_eq!(res_obj.total, 1, "total should be 1");
             assert_eq!(res_obj.items.len(), 1, "items length should be 1");
@@ -408,7 +406,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
             assert_eq!(res_obj.total, 1, "total should be 1");
             assert_eq!(res_obj.items.len(), 1, "items length should be 1");
@@ -432,7 +430,7 @@ mod tests {
                 },
                 ..Default::default()
             };
-            let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+            let res = api.search_assets(payload).await.unwrap();
             let res_obj: AssetList = serde_json::from_value(res).unwrap();
 
             assert_eq!(res_obj.total, 1, "total should be 1");
@@ -446,15 +444,13 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_asset_none_grouping_with_token_standard() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let pb = Pubkey::new_unique();
         let authority = Pubkey::new_unique();
@@ -557,7 +553,7 @@ mod tests {
             id: pb.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         assert_eq!(response["grouping"], Value::Array(vec![]));
         assert_eq!(response["content"]["metadata"]["token_standard"], "NonFungible");
@@ -565,14 +561,12 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_metadata_sanitizer() {
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create(&cli, 0, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let whitespace_options = " \t\n\r\x0B\x0C\u{00A0}\u{1680}\u{2000}\u{2001}\u{2002}\u{2003}\
         \u{2004}\u{2005}\u{2006}\u{2007}\u{2008}\u{2009}\u{200A}\u{2028}\
@@ -680,7 +674,7 @@ mod tests {
                 id: pb.to_string(),
                 options: Options { show_unverified_collections: true, ..Default::default() },
             };
-            let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+            let response = api.get_asset(payload).await.unwrap();
             assert_eq!(
                 response["content"]["metadata"]["name"],
                 format!("{} name {}", whitespace, whitespace)
@@ -692,15 +686,13 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_asset_without_offchain_data() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let pb = Pubkey::new_unique();
         let authority = Pubkey::new_unique();
@@ -776,7 +768,7 @@ mod tests {
             id: pb.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         assert_eq!(response["id"], pb.to_string());
         assert_eq!(response["grouping"], Value::Array(vec![]));
@@ -786,7 +778,7 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_fungible_asset() {
         let cnt = 20;
@@ -794,8 +786,6 @@ mod tests {
         let (env, _) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let token_updates_processor =
             TokenAccountsProcessor::new(Arc::new(IngesterMetricsConfig::new()));
@@ -897,7 +887,7 @@ mod tests {
             id: mint_key.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         assert_eq!(response["ownership"]["ownership_model"], "single");
         assert_eq!(response["ownership"]["owner"], owner_key.to_string());
@@ -929,7 +919,7 @@ mod tests {
             id: mint_key.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         assert_eq!(response["ownership"]["ownership_model"], "token");
         assert_eq!(response["ownership"]["owner"], "");
@@ -938,7 +928,7 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_asset_programable_interface() {
         let cnt = 20;
@@ -946,8 +936,6 @@ mod tests {
         let (env, _) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let token_updates_processor =
             TokenAccountsProcessor::new(Arc::new(IngesterMetricsConfig::new()));
@@ -1074,7 +1062,7 @@ mod tests {
             id: mint_accs[0].pubkey.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         assert_eq!(response["id"], mint_accs[0].pubkey.to_string());
         assert_eq!(response["interface"], "ProgrammableNFT".to_string());
@@ -1083,7 +1071,7 @@ mod tests {
             id: mint_accs[1].pubkey.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         assert_eq!(response["id"], mint_accs[1].pubkey.to_string());
         assert_eq!(response["interface"], "ProgrammableNFT".to_string());
@@ -1091,15 +1079,13 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_burnt() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let token_updates_processor =
             TokenAccountsProcessor::new(Arc::new(IngesterMetricsConfig::new()));
@@ -1219,7 +1205,7 @@ mod tests {
             id: mint_key.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         assert_eq!(response["ownership"]["ownership_model"], "single");
         assert_eq!(response["ownership"]["owner"], owner_key.to_string());
@@ -1229,7 +1215,7 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_asset_signatures() {
         let cnt = 20;
         let cli = Cli::default();
@@ -1421,7 +1407,7 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_token_accounts() {
         let cnt = 20;
         let cli = Cli::default();
@@ -1615,7 +1601,7 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_token_accounts_pagination() {
         let cnt = 20;
         let cli = Cli::default();
@@ -1839,15 +1825,13 @@ mod tests {
         assert_eq!(combined_10_30, first_30.token_accounts[10..]);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_get_assets_by_owner() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, generated_assets) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let ref_value = generated_assets.owners[8].clone();
         let payload = GetAssetsByOwner {
@@ -1863,7 +1847,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = api.get_assets_by_owner(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_assets_by_owner(payload).await.unwrap();
         let res_obj: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res_obj.total, 1, "total should be 1");
@@ -1875,15 +1859,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_get_assets_by_group() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, generated_assets) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let ref_value = generated_assets.collections[12].clone();
         let payload = GetAssetsByGroup {
@@ -1900,7 +1882,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = api.get_assets_by_group(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_assets_by_group(payload).await.unwrap();
         let res_obj: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res_obj.total, 1, "total should be 1");
@@ -1912,15 +1894,13 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_get_assets_by_creator() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, generated_assets) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let ref_value = generated_assets.dynamic_details[5].clone();
         let payload = GetAssetsByCreator {
@@ -1937,7 +1917,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = api.get_assets_by_creator(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_assets_by_creator(payload).await.unwrap();
         let res_obj: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res_obj.total, 1, "total should be 1");
@@ -1949,7 +1929,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_get_assets_by_authority() {
         let cnt = 20;
@@ -1957,8 +1937,6 @@ mod tests {
         let (env, generated_assets) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let ref_value = generated_assets.authorities[9].clone();
         let payload = GetAssetsByAuthority {
@@ -1974,7 +1952,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = api.get_assets_by_authority(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_assets_by_authority(payload).await.unwrap();
         let res_obj: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res_obj.total, 1, "total should be 1");
@@ -2012,14 +1990,12 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_json_middleware() {
         let cnt = 20;
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create(&cli, cnt, SLOT_UPDATED).await;
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let url = "http://someUrl.com".to_string();
 
@@ -2164,7 +2140,7 @@ mod tests {
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
 
-        let response = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload).await.unwrap();
 
         let expected_content: Value = serde_json::from_str(
             r#"
@@ -2205,7 +2181,7 @@ mod tests {
         env.teardown().await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_cannot_service_gaped_tree() {
         let cnt = 20;
         let cli = Cli::default();
@@ -2260,7 +2236,7 @@ mod tests {
         assert!(matches!(res, DasApiError::CannotServiceRequest));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_core_account_fees() {
         let cnt = 20;
         let cli = Cli::default();
@@ -2307,15 +2283,13 @@ mod tests {
         assert_eq!(res.core_fees_account.len(), 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_search_assets_grand_total() {
         let total_assets = 2000;
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create(&cli, total_assets, SLOT_UPDATED).await;
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let payload = SearchAssets {
             limit: Some(1000),
             page: Some(1),
@@ -2326,7 +2300,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
         assert_eq!(res.grand_total, Some(total_assets as u32));
 
@@ -2340,7 +2314,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
         assert_eq!(res.grand_total, Some(0));
 
@@ -2353,7 +2327,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
         assert_eq!(res.grand_total, None);
     }
@@ -2397,8 +2371,6 @@ mod tests {
             NATIVE_MINT_PUBKEY.to_string(),
         );
 
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let payload = SearchAssets {
             limit: Some(1000),
             page: Some(1),
@@ -2410,7 +2382,7 @@ mod tests {
             },
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
         assert!(res.native_balance.unwrap().total_price > 0.0);
     }
@@ -2500,8 +2472,6 @@ mod tests {
         o.await.unwrap();
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let payload = GetAsset {
             id: generated_assets.collections.first().unwrap().pubkey.to_string(),
             options: Options {
@@ -2510,7 +2480,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_asset(payload).await.unwrap();
         let res: Asset = serde_json::from_value(res).unwrap();
 
         assert_eq!(
@@ -2588,7 +2558,7 @@ mod tests {
             id: generated_assets.collections.first().unwrap().pubkey.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let res = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_asset(payload).await.unwrap();
         let res: Asset = serde_json::from_value(res).unwrap();
 
         assert!(res.grouping.clone().unwrap().first().unwrap().collection_metadata.is_none());
@@ -2630,8 +2600,6 @@ mod tests {
         }).unwrap();
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let payload = GetAsset {
             id: asset_pk.to_string(),
             options: Options {
@@ -2640,7 +2608,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_asset(payload).await.unwrap();
         let res: Asset = serde_json::from_value(res).unwrap();
         assert_eq!(
             res.inscription.unwrap().validation_hash.unwrap(),
@@ -2656,7 +2624,7 @@ mod tests {
                 ..Default::default()
             },
         };
-        let res = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_asset(payload).await.unwrap();
         let res: Asset = serde_json::from_value(res).unwrap();
         assert_eq!(res.inscription, None);
         assert_eq!(res.spl20, None);
@@ -2664,9 +2632,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_assets_get_all_spec_classes() {
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
-
         let number_items = 100;
         let cli = Cli::default();
 
@@ -2704,7 +2669,7 @@ mod tests {
             token_type: Some(TokenType::All),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res.items.len(), number_items);
@@ -2712,9 +2677,6 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread")]
     async fn test_search_assets_freeze_delegate_authorities_for_fungible() {
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
-
         let number_items = 100;
         let cli = Cli::default();
 
@@ -2804,9 +2766,8 @@ mod tests {
             .transform_and_save_mint_account(&mut batch_storage, &mint, &Default::default())
             .unwrap();
         batch_storage.flush().unwrap();
-        let (_, rx) = tokio::sync::broadcast::channel::<()>(1);
 
-        let synchronizer = nft_ingester::index_syncronizer::Synchronizer::new(
+        let synchronizer = nft_ingester::index_synchronizer::Synchronizer::new(
             env.rocks_env.storage.clone(),
             env.pg_env.client.clone(),
             200_000,
@@ -2815,28 +2776,19 @@ mod tests {
             1,
         );
         let synchronizer = Arc::new(synchronizer);
-        let mut tasks = JoinSet::new();
 
         for asset_type in ASSET_TYPES {
-            let rx = rx.resubscribe();
             let synchronizer = synchronizer.clone();
-            match asset_type {
+            let _ = match asset_type {
                 AssetType::Fungible => {
-                    tasks.spawn(async move {
-                        synchronizer.synchronize_fungible_asset_indexes(&rx, 0).await
-                    });
+                    synchronizer
+                        .synchronize_fungible_asset_indexes(CancellationToken::new(), 0)
+                        .await
                 },
                 AssetType::NonFungible => {
-                    tasks.spawn(
-                        async move { synchronizer.synchronize_nft_asset_indexes(&rx, 0).await },
-                    );
+                    synchronizer.synchronize_nft_asset_indexes(CancellationToken::new(), 0).await
                 },
-            }
-        }
-        while let Some(res) = tasks.join_next().await {
-            if let Err(err) = res {
-                panic!("{err}");
-            }
+            };
         }
 
         let payload = SearchAssets {
@@ -2853,7 +2805,7 @@ mod tests {
         };
 
         let api = create_api(&env, None);
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res.items.len(), 1);
@@ -2873,7 +2825,7 @@ mod tests {
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create_noise(&cli, cnt, 100).await;
 
-        let synchronizer = nft_ingester::index_syncronizer::Synchronizer::new(
+        let synchronizer = nft_ingester::index_synchronizer::Synchronizer::new(
             env.rocks_env.storage.clone(),
             env.pg_env.client.clone(),
             200_000,
@@ -3023,37 +2975,24 @@ mod tests {
             .transform_and_save_mint_account(&mut batch_storage, &mint2, &Default::default())
             .unwrap();
         batch_storage.flush().unwrap();
-        let (_, rx) = tokio::sync::broadcast::channel::<()>(1);
 
         let synchronizer = Arc::new(synchronizer);
-        let mut tasks = JoinSet::new();
 
         for asset_type in ASSET_TYPES {
-            let rx = rx.resubscribe();
             let synchronizer = synchronizer.clone();
-            match asset_type {
+            let _ = match asset_type {
                 AssetType::Fungible => {
-                    tasks.spawn(async move {
-                        synchronizer.synchronize_fungible_asset_indexes(&rx, 0).await
-                    });
+                    synchronizer
+                        .synchronize_fungible_asset_indexes(CancellationToken::new(), 0)
+                        .await
                 },
                 AssetType::NonFungible => {
-                    tasks.spawn(
-                        async move { synchronizer.synchronize_nft_asset_indexes(&rx, 0).await },
-                    );
+                    synchronizer.synchronize_nft_asset_indexes(CancellationToken::new(), 0).await
                 },
-            }
-        }
-
-        while let Some(res) = tasks.join_next().await {
-            if let Err(err) = res {
-                panic!("{err}");
-            }
+            };
         }
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let payload = SearchAssets {
             limit: Some(1000),
             page: Some(1),
@@ -3066,7 +3005,7 @@ mod tests {
             token_type: Some(TokenType::Fungible),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res.items.len(), 2, "SearchAssets get by owner_address and token_type Fungible");
@@ -3111,7 +3050,7 @@ mod tests {
             token_type: Some(TokenType::All),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         // Totally we have 2 assets with required owner. show_fungible is false by default, so we don't have token info.
@@ -3131,7 +3070,7 @@ mod tests {
             token_type: Some(TokenType::Fungible),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         // We have only 1 token account with non-zero balance
@@ -3216,13 +3155,11 @@ mod tests {
         batch_storage.flush().unwrap();
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let payload = GetAsset {
             id: fungible_token_mint1.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let res = api.get_asset(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.get_asset(payload).await.unwrap();
         let res: Asset = serde_json::from_value(res).unwrap();
 
         let reference = json!({
@@ -3269,7 +3206,7 @@ mod tests {
         )
         .await;
 
-        let synchronizer = nft_ingester::index_syncronizer::Synchronizer::new(
+        let synchronizer = nft_ingester::index_synchronizer::Synchronizer::new(
             env.rocks_env.storage.clone(),
             env.pg_env.client.clone(),
             200_000,
@@ -3358,37 +3295,23 @@ mod tests {
             .unwrap();
         batch_storage.flush().unwrap();
 
-        let (_, rx) = tokio::sync::broadcast::channel::<()>(1);
-
         let synchronizer = Arc::new(synchronizer);
-        let mut tasks = JoinSet::new();
 
         for asset_type in ASSET_TYPES {
-            let rx = rx.resubscribe();
             let synchronizer = synchronizer.clone();
-            match asset_type {
+            let _ = match asset_type {
                 AssetType::Fungible => {
-                    tasks.spawn(async move {
-                        synchronizer.synchronize_fungible_asset_indexes(&rx, 0).await
-                    });
+                    synchronizer
+                        .synchronize_fungible_asset_indexes(CancellationToken::new(), 0)
+                        .await
                 },
                 AssetType::NonFungible => {
-                    tasks.spawn(
-                        async move { synchronizer.synchronize_nft_asset_indexes(&rx, 0).await },
-                    );
+                    synchronizer.synchronize_nft_asset_indexes(CancellationToken::new(), 0).await
                 },
-            }
-        }
-
-        while let Some(res) = tasks.join_next().await {
-            if let Err(err) = res {
-                panic!("{err}");
-            }
+            };
         }
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
         let payload = SearchAssets {
             limit: Some(1000),
             page: Some(1),
@@ -3403,7 +3326,7 @@ mod tests {
             token_type: Some(TokenType::Fungible),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         // We created 2 fungible tokens^ 1 with real pubkey (MPLX)
@@ -3435,7 +3358,7 @@ mod tests {
             pg_mount.to_str().unwrap(),
         )
         .await;
-        let synchronizer = nft_ingester::index_syncronizer::Synchronizer::new(
+        let synchronizer = nft_ingester::index_synchronizer::Synchronizer::new(
             env.rocks_env.storage.clone(),
             env.pg_env.client.clone(),
             200_000,
@@ -3495,11 +3418,8 @@ mod tests {
         assert_eq!(idx_fungible_asset_iter.count(), 1);
         assert_eq!(idx_non_fungible_asset_iter.count(), cnt + 2);
 
-        let (_, rx) = tokio::sync::broadcast::channel(1);
-
         for asset_type in ASSET_TYPES {
-            let rx = rx.resubscribe();
-            synchronizer.full_syncronize(&rx, asset_type).await.expect("sync");
+            synchronizer.full_syncronize(CancellationToken::new(), asset_type).await.expect("sync");
             clean_syncronized_idxs(
                 env.pg_env.client.clone(),
                 env.rocks_env.storage.clone(),
@@ -3601,7 +3521,7 @@ mod tests {
             temp_dir_path.to_str().unwrap(),
         )
         .await;
-        let synchronizer = nft_ingester::index_syncronizer::Synchronizer::new(
+        let synchronizer = nft_ingester::index_synchronizer::Synchronizer::new(
             env.rocks_env.storage.clone(),
             env.pg_env.client.clone(),
             10,
@@ -3644,9 +3564,8 @@ mod tests {
                 .unwrap();
             batch_storage.flush().unwrap();
         }
-        let (_tx, rx) = tokio::sync::broadcast::channel::<()>(1);
         for asset_type in ASSET_TYPES {
-            synchronizer.full_syncronize(&rx, asset_type).await.unwrap();
+            synchronizer.full_syncronize(CancellationToken::new(), asset_type).await.unwrap();
         }
 
         // receive 5 more updates for the same asset
@@ -3724,7 +3643,7 @@ mod tests {
         )
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_static_details_transition_from_fungible_into_nft() {
         // Given Fungible Metadata
@@ -3756,8 +3675,6 @@ mod tests {
             Arc::new(RaydiumTokenPriceFetcher::default()),
             NATIVE_MINT_PUBKEY.to_string(),
         );
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let token_updates_processor =
             TokenAccountsProcessor::new(Arc::new(IngesterMetricsConfig::new()));
@@ -3859,7 +3776,7 @@ mod tests {
             id: mint_key.to_string(),
             options: Options { show_unverified_collections: true, ..Default::default() },
         };
-        let response = api.get_asset(payload.clone(), mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload.clone()).await.unwrap();
 
         assert_eq!(response["interface"], "FungibleToken".to_string());
 
@@ -3884,7 +3801,7 @@ mod tests {
             )
             .unwrap();
         batch_storage.flush().unwrap();
-        let response = api.get_asset(payload.clone(), mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload.clone()).await.unwrap();
 
         assert_eq!(response["interface"], "V1_NFT".to_string());
 
@@ -3908,7 +3825,7 @@ mod tests {
             )
             .unwrap();
         batch_storage.flush().unwrap();
-        let response = api.get_asset(payload.clone(), mutexed_tasks.clone()).await.unwrap();
+        let response = api.get_asset(payload.clone()).await.unwrap();
 
         assert_eq!(response["interface"], "V1_NFT".to_string());
     }
@@ -3920,7 +3837,7 @@ mod tests {
         let cli = Cli::default();
         let (env, _) = setup::TestEnvironment::create_noise(&cli, cnt, 100).await;
 
-        let synchronizer = nft_ingester::index_syncronizer::Synchronizer::new(
+        let synchronizer = nft_ingester::index_synchronizer::Synchronizer::new(
             env.rocks_env.storage.clone(),
             env.pg_env.client.clone(),
             200_000,
@@ -4084,37 +4001,24 @@ mod tests {
             .transform_and_save_mint_account(&mut batch_storage, &mint2, &Default::default())
             .unwrap();
         batch_storage.flush().unwrap();
-        let (_, rx) = tokio::sync::broadcast::channel::<()>(1);
 
         let synchronizer = Arc::new(synchronizer);
-        let mut tasks = JoinSet::new();
 
         for asset_type in ASSET_TYPES {
-            let rx = rx.resubscribe();
             let synchronizer = synchronizer.clone();
-            match asset_type {
+            let _ = match asset_type {
                 AssetType::Fungible => {
-                    tasks.spawn(async move {
-                        synchronizer.synchronize_fungible_asset_indexes(&rx, 0).await
-                    });
+                    synchronizer
+                        .synchronize_fungible_asset_indexes(CancellationToken::new(), 0)
+                        .await
                 },
                 AssetType::NonFungible => {
-                    tasks.spawn(
-                        async move { synchronizer.synchronize_nft_asset_indexes(&rx, 0).await },
-                    );
+                    synchronizer.synchronize_nft_asset_indexes(CancellationToken::new(), 0).await
                 },
-            }
-        }
-
-        while let Some(res) = tasks.join_next().await {
-            if let Err(err) = res {
-                panic!("{err}");
-            }
+            };
         }
 
         let api = create_api(&env, None);
-        let tasks = JoinSet::new();
-        let mutexed_tasks = Arc::new(Mutex::new(tasks));
 
         let payload = SearchAssets {
             limit: Some(1000),
@@ -4128,7 +4032,7 @@ mod tests {
             token_type: Some(TokenType::Fungible),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(
@@ -4149,7 +4053,7 @@ mod tests {
             token_type: Some(TokenType::All),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(res.items.len(), 2, "SearchAssets by token_type:All show_zero_balance: true");
@@ -4168,7 +4072,7 @@ mod tests {
             token_type: Some(TokenType::NonFungible),
             ..Default::default()
         };
-        let res = api.search_assets(payload, mutexed_tasks.clone()).await.unwrap();
+        let res = api.search_assets(payload).await.unwrap();
         let res: AssetList = serde_json::from_value(res).unwrap();
 
         assert_eq!(

--- a/nft_ingester/tests/asset_previews_tests.rs
+++ b/nft_ingester/tests/asset_previews_tests.rs
@@ -10,7 +10,7 @@ mod tests {
     use setup::rocks::RocksTestEnvironment;
     use solana_sdk::keccak::{self, HASH_BYTES};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_replace_file_urls_with_preview_urls() {
         let rocks_env = RocksTestEnvironment::new(&[]);
@@ -124,7 +124,7 @@ mod tests {
 
     // This test demostrates that elements in the result of batch_get call
     // preserves same order as keys in argument
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_rocks_batch_get_order() {
         let rocks_env = RocksTestEnvironment::new(&[]);

--- a/nft_ingester/tests/backfill_tests.rs
+++ b/nft_ingester/tests/backfill_tests.rs
@@ -15,7 +15,7 @@ mod tests {
     use solana_program::pubkey::Pubkey;
     use usecase::{bigtable::BigTableClient, slots_collector::SlotsCollector};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_consume_a_block_and_check_if_processed() {
         let (_tx, rx) = tokio::sync::broadcast::channel(1);
@@ -45,7 +45,7 @@ mod tests {
         assert_eq!(persisted, original_block);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_collect_slots() {
         let (_tx, mut rx) = tokio::sync::broadcast::channel(1);
@@ -66,7 +66,7 @@ mod tests {
             .await;
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_get_max_u64_request() {
         let (_tx, mut rx) = tokio::sync::broadcast::channel(1);

--- a/nft_ingester/tests/process_accounts.rs
+++ b/nft_ingester/tests/process_accounts.rs
@@ -76,7 +76,7 @@ mod tests {
         }
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn token_update_process() {
         let first_mint = Pubkey::new_unique();
         let second_mint = Pubkey::new_unique();
@@ -189,7 +189,7 @@ mod tests {
         assert_eq!(second_dynamic_from_db.supply.unwrap().value, 1);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn mplx_update_process() {
         let first_mint = Pubkey::new_unique();
         let second_mint = Pubkey::new_unique();
@@ -297,7 +297,7 @@ mod tests {
         };
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn mpl_core_update_process() {
         let first_mpl_core = Pubkey::new_unique();
         let first_owner = Pubkey::new_unique();
@@ -472,7 +472,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn inscription_process() {
         // real world accounts
         let inscription_account_data = general_purpose::STANDARD_NO_PAD.decode("ZAuXKuQmRbsAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAF00JG/taM5xDErn+0mQMBbbBdJuhYeh30FuRLrqWSbfBhAAAABhcHBsaWNhdGlvbi90ZXh0AeOkcaHjppsua2rgJHv2TUkEEClH4Y96jMvvKr1caFZzE7QEAAAAAABDAAAAAUAAAABmNTMyMGVmMjhkNTM3NWQ3YjFhNmFlNzBlYzQzZWRkMTE1ZmQxMmVhOTMzZTAxNjUzMDZhNzg4ZGNiZWVjYTMxAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").unwrap() ;

--- a/nft_ingester/tests/sequence_consistent_tests.rs
+++ b/nft_ingester/tests/sequence_consistent_tests.rs
@@ -5,7 +5,7 @@ mod tests {
 
     #[cfg(feature = "integration_tests")]
     #[tracing_test::traced_test]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_range_delete() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let first_tree_key = solana_program::pubkey::Pubkey::from_str(
@@ -56,7 +56,7 @@ mod tests {
 
     #[cfg(feature = "rpc_tests")]
     #[tracing_test::traced_test]
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_fill_gap() {
         use std::sync::Arc;
 

--- a/rocks-db/Cargo.toml
+++ b/rocks-db/Cargo.toml
@@ -46,6 +46,7 @@ num-traits = { workspace = true }
 # using a different version of flatbuffer compared to the rest of the project as this one is compatible with generator used for AssetCompleteDetails structures
 flatbuffers = { version="24.3.25", features = ["serialize"]} 
 indicatif = { workspace = true }
+tokio-util = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/rocks-db/src/bin/column_copier/main.rs
+++ b/rocks-db/src/bin/column_copier/main.rs
@@ -11,7 +11,7 @@ use rocks_db::{
     column::TypedColumn, columns::offchain_data::OffChainData, migrator::MigrationState, Storage,
 };
 use tempfile::TempDir;
-use tokio::{sync::Mutex, task::JoinSet};
+use tokio::task::JoinSet;
 
 const BATCH_SIZE: usize = 10_000;
 
@@ -65,18 +65,12 @@ async fn copy_column_families(
     let source_db = Storage::open_secondary(
         source_path,
         secondary_source_path,
-        Arc::new(Mutex::new(JoinSet::new())),
         red_metrics.clone(),
         MigrationState::Last,
     )
     .map_err(|e| e.to_string())?;
-    let destination_db = Storage::open(
-        destination_path,
-        Arc::new(Mutex::new(JoinSet::new())),
-        red_metrics.clone(),
-        MigrationState::Last,
-    )
-    .map_err(|e| e.to_string())?;
+    let destination_db = Storage::open(destination_path, red_metrics.clone(), MigrationState::Last)
+        .map_err(|e| e.to_string())?;
     let mut set = JoinSet::new();
 
     // Create a MultiProgress to manage multiple progress bars

--- a/rocks-db/src/bin/fork_detector/main.rs
+++ b/rocks-db/src/bin/fork_detector/main.rs
@@ -9,7 +9,6 @@ use rocks_db::{
     SlotStorage, Storage,
 };
 use solana_sdk::pubkey::Pubkey;
-use tokio::{sync::Mutex, task::JoinSet};
 
 const BATCH_TO_DROP: usize = 1000;
 
@@ -42,10 +41,8 @@ async fn find_forks(source_path: &str) -> Result<(), String> {
 
     println!("Opening DB...");
 
-    let js = Arc::new(Mutex::new(JoinSet::new()));
-    let source_db =
-        Storage::open(source_path, js.clone(), red_metrics.clone(), MigrationState::Last)
-            .map_err(|e| e.to_string())?;
+    let source_db = Storage::open(source_path, red_metrics.clone(), MigrationState::Last)
+        .map_err(|e| e.to_string())?;
 
     println!("Opened in {:?}", start.elapsed());
 
@@ -53,7 +50,6 @@ async fn find_forks(source_path: &str) -> Result<(), String> {
         SlotStorage::open_secondary(
             source_path, // FIXME: provide correct paths for slots storage
             source_path,
-            js.clone(),
             red_metrics.clone(),
         )
         .expect("should open slots db"),

--- a/rocks-db/src/bin/leaf_checker/main.rs
+++ b/rocks-db/src/bin/leaf_checker/main.rs
@@ -8,7 +8,7 @@ use rocks_db::{
     Storage,
 };
 use solana_sdk::pubkey::Pubkey;
-use tokio::{sync::Mutex, task::JoinSet};
+use tokio::task::JoinSet;
 
 pub const NUM_OF_THREADS: usize = 2500;
 
@@ -28,15 +28,8 @@ pub async fn main() {
 
     println!("Opening DB...");
 
-    let source_db = Arc::new(
-        Storage::open(
-            source_db_path,
-            Arc::new(Mutex::new(JoinSet::new())),
-            red_metrics.clone(),
-            MigrationState::Last,
-        )
-        .unwrap(),
-    );
+    let source_db =
+        Arc::new(Storage::open(source_db_path, red_metrics.clone(), MigrationState::Last).unwrap());
 
     println!("Opened in {:?}", start.elapsed());
 

--- a/rocks-db/src/clients/asset_streaming_client.rs
+++ b/rocks-db/src/clients/asset_streaming_client.rs
@@ -39,7 +39,7 @@ impl AssetDetailsStreamer for Storage {
         let (tx, rx) = tokio::sync::mpsc::channel(32);
         let backend = self.slot_asset_idx.backend.clone();
         let metrics = self.red_metrics.clone();
-        self.join_set.lock().await.spawn(tokio::spawn(async move {
+        usecase::executor::spawn(async move {
             let _ = process_asset_details_range(
                 backend,
                 start_slot,
@@ -48,7 +48,7 @@ impl AssetDetailsStreamer for Storage {
                 tx.clone(),
             )
             .await;
-        }));
+        });
 
         Ok(Box::pin(ReceiverStream::new(rx)) as AssetDetailsStream)
     }

--- a/rocks-db/src/clients/raw_blocks_streaming_client.rs
+++ b/rocks-db/src/clients/raw_blocks_streaming_client.rs
@@ -21,7 +21,7 @@ impl RawBlocksStreamer for SlotStorage {
         let (tx, rx) = tokio::sync::mpsc::channel(32);
         let backend = self.db.clone();
         let metrics = self.red_metrics.clone();
-        self.join_set.lock().await.spawn(tokio::spawn(async move {
+        usecase::executor::spawn(async move {
             let _ = process_raw_blocks_range(
                 backend,
                 start_slot,
@@ -30,7 +30,7 @@ impl RawBlocksStreamer for SlotStorage {
                 tx.clone(),
             )
             .await;
-        }));
+        });
 
         Ok(Box::pin(ReceiverStream::new(rx)) as RawBlocksStream)
     }

--- a/rocks-db/src/migrator.rs
+++ b/rocks-db/src/migrator.rs
@@ -9,7 +9,6 @@ use interface::migration_version_manager::PrimaryStorageMigrationVersionManager;
 use metrics_utils::red::RequestErrorDurationMetrics;
 use rocksdb::{IteratorMode, DB};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
-use tokio::{sync::Mutex, task::JoinSet};
 use tracing::{error, info};
 
 use crate::{
@@ -196,7 +195,6 @@ impl<'a> MigrationApplier<'a> {
     fn open_migration_storage(db_path: &str, version: u64) -> Result<Storage> {
         Storage::open(
             db_path,
-            Arc::new(Mutex::new(JoinSet::new())),
             Arc::new(RequestErrorDurationMetrics::new()),
             MigrationState::Version(version),
         )

--- a/rocks-db/src/storage_traits.rs
+++ b/rocks-db/src/storage_traits.rs
@@ -4,6 +4,7 @@ use async_trait::async_trait;
 use entities::models::{AssetIndex, FungibleAssetIndex};
 use mockall::automock;
 use solana_sdk::pubkey::Pubkey;
+use tokio_util::sync::CancellationToken;
 
 pub use crate::Result;
 use crate::Storage;
@@ -66,7 +67,7 @@ pub trait Dumper {
         asset_limit: Option<usize>,
         start_pubkey: Option<Pubkey>,
         end_pubkey: Option<Pubkey>,
-        rx: &tokio::sync::broadcast::Receiver<()>,
+        cancellation_token: CancellationToken,
         synchronizer_metrics: std::sync::Arc<metrics_utils::SynchronizerMetricsConfig>,
     ) -> core::result::Result<usize, String>;
 
@@ -76,7 +77,7 @@ pub trait Dumper {
         buf_capacity: usize,
         start_pubkey: Option<Pubkey>,
         end_pubkey: Option<Pubkey>,
-        rx: &tokio::sync::broadcast::Receiver<()>,
+        cancellation_token: CancellationToken,
         synchronizer_metrics: std::sync::Arc<metrics_utils::SynchronizerMetricsConfig>,
     ) -> core::result::Result<usize, String>;
 }
@@ -156,7 +157,7 @@ impl Dumper for MockAssetIndexStorage {
         asset_limit: Option<usize>,
         start_pubkey: Option<Pubkey>,
         end_pubkey: Option<Pubkey>,
-        rx: &tokio::sync::broadcast::Receiver<()>,
+        cancellation_token: CancellationToken,
         synchronizer_metrics: std::sync::Arc<metrics_utils::SynchronizerMetricsConfig>,
     ) -> core::result::Result<usize, String> {
         self.mock_dumper.dump_nft_csv(
@@ -168,7 +169,7 @@ impl Dumper for MockAssetIndexStorage {
             asset_limit,
             start_pubkey,
             end_pubkey,
-            rx,
+            cancellation_token,
             synchronizer_metrics,
         )
     }
@@ -178,7 +179,7 @@ impl Dumper for MockAssetIndexStorage {
         buf_capacity: usize,
         start_pubkey: Option<Pubkey>,
         end_pubkey: Option<Pubkey>,
-        rx: &tokio::sync::broadcast::Receiver<()>,
+        cancellation_token: CancellationToken,
         synchronizer_metrics: std::sync::Arc<metrics_utils::SynchronizerMetricsConfig>,
     ) -> core::result::Result<usize, String> {
         self.mock_dumper.dump_fungible_csv(
@@ -186,7 +187,7 @@ impl Dumper for MockAssetIndexStorage {
             buf_capacity,
             start_pubkey,
             end_pubkey,
-            rx,
+            cancellation_token,
             synchronizer_metrics,
         )
     }

--- a/rocks-db/tests/asset_streaming_client_tests.rs
+++ b/rocks-db/tests/asset_streaming_client_tests.rs
@@ -8,7 +8,7 @@ mod tests {
     use solana_sdk::pubkey::Pubkey;
     use tokio_stream::StreamExt;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_asset_details_stream_in_range_empty_db() {
         let storage = RocksTestEnvironment::new(&[]).storage;
 
@@ -22,7 +22,7 @@ mod tests {
         assert!(stream.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_asset_details_stream_in_range_data_only_before_target() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let pk = Pubkey::new_unique();
@@ -38,7 +38,7 @@ mod tests {
         assert!(stream.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_asset_details_stream_in_range_data_only_after_target() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let pk = Pubkey::new_unique();
@@ -54,7 +54,7 @@ mod tests {
         assert!(stream.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_asset_details_stream_in_range_data_missing_data() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let pk = Pubkey::new_unique();
@@ -76,7 +76,7 @@ mod tests {
         assert!(stream.next().await.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_asset_details_stream_in_range_data() {
         let cnt = 1000;
         let env = RocksTestEnvironment::new(&[]);
@@ -99,7 +99,7 @@ mod tests {
         assert_eq!(pk_set, pks.pubkeys.into_iter().collect::<HashSet<_>>());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_get_raw_blocks_stream_in_range_data() {
         let env = RocksTestEnvironment::new(&[]);
         let slot_storage = &env.slot_storage;

--- a/rocks-db/tests/batch_client_integration_tests.rs
+++ b/rocks-db/tests/batch_client_integration_tests.rs
@@ -12,7 +12,6 @@ mod tests {
     use setup::rocks::{RocksTestEnvironment, DEFAULT_PUBKEY_OF_ONES, PUBKEY_OF_TWOS};
     use solana_sdk::pubkey::Pubkey;
     use tempfile::TempDir;
-    use tokio::{sync::Mutex, task::JoinSet};
 
     #[test]
     fn test_process_asset_updates_batch_empty_db() {
@@ -20,7 +19,6 @@ mod tests {
         let red_metrics = Arc::new(RequestErrorDurationMetrics::new());
         let storage = Storage::open(
             temp_dir.path().to_str().unwrap(),
-            Arc::new(Mutex::new(JoinSet::new())),
             red_metrics.clone(),
             MigrationState::Last,
         )

--- a/rocks-db/tests/dump_tests.rs
+++ b/rocks-db/tests/dump_tests.rs
@@ -4,6 +4,7 @@ use metrics_utils::SynchronizerMetricsConfig;
 use rocks_db::storage_traits::Dumper;
 use setup::rocks::*;
 use tempfile::TempDir;
+use tokio_util::sync::CancellationToken;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 10)]
 #[tracing_test::traced_test]
@@ -12,7 +13,6 @@ async fn test_scv_export_from_rocks() {
     let number_of_assets = 1000;
     let _generated_assets = env.generate_assets(number_of_assets, 25).await;
     let storage = env.storage;
-    let (_tx, rx) = tokio::sync::broadcast::channel::<()>(1);
     let temp_dir = TempDir::new().expect("Failed to create a temporary directory");
     let assets_path = format!("{}/assets.csv", temp_dir.path().to_str().unwrap());
     let creators_path = format!("{}/creators.csv", temp_dir.path().to_str().unwrap());
@@ -35,7 +35,7 @@ async fn test_scv_export_from_rocks() {
             Some(number_of_assets),
             None,
             None,
-            &rx,
+            CancellationToken::new(),
             Arc::new(SynchronizerMetricsConfig::new()),
         )
         .unwrap();
@@ -46,7 +46,7 @@ async fn test_scv_export_from_rocks() {
             155,
             None,
             None,
-            &rx,
+            CancellationToken::new(),
             Arc::new(SynchronizerMetricsConfig::new()),
         )
         .unwrap();

--- a/rocks-db/tests/migration_tests.rs
+++ b/rocks-db/tests/migration_tests.rs
@@ -15,9 +15,8 @@ mod tests {
     };
     use solana_sdk::pubkey::Pubkey;
     use tempfile::TempDir;
-    use tokio::{sync::Mutex, task::JoinSet};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_migration() {
         let dir = TempDir::new().unwrap();
         let v1 = OffChainDataDeprecated {
@@ -33,7 +32,6 @@ mod tests {
         let path = dir.path().to_str().unwrap();
         let old_storage = Storage::open(
             path,
-            Arc::new(Mutex::new(JoinSet::new())),
             Arc::new(RequestErrorDurationMetrics::new()),
             MigrationState::Version(0),
         )
@@ -51,7 +49,6 @@ mod tests {
         let migration_version_manager = Storage::open_secondary(
             path,
             secondary_storage_dir.path().to_str().unwrap(),
-            Arc::new(Mutex::new(JoinSet::new())),
             Arc::new(RequestErrorDurationMetrics::new()),
             MigrationState::Version(4),
         )
@@ -68,7 +65,6 @@ mod tests {
 
         let new_storage = Storage::open(
             path,
-            Arc::new(Mutex::new(JoinSet::new())),
             Arc::new(RequestErrorDurationMetrics::new()),
             MigrationState::Version(4),
         )
@@ -117,7 +113,7 @@ mod tests {
         assert_eq!(migrated_v2.last_read_at, 0);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_clitems_v2_migration() {
         let dir = TempDir::new().unwrap();
         let node_id = 32782;
@@ -142,7 +138,6 @@ mod tests {
         let path = dir.path().to_str().unwrap();
         let old_storage = Storage::open(
             path,
-            Arc::new(Mutex::new(JoinSet::new())),
             Arc::new(RequestErrorDurationMetrics::new()),
             MigrationState::Version(0),
         )
@@ -153,7 +148,6 @@ mod tests {
         let migration_version_manager = Storage::open_secondary(
             path,
             secondary_storage_dir.path().to_str().unwrap(),
-            Arc::new(Mutex::new(JoinSet::new())),
             Arc::new(RequestErrorDurationMetrics::new()),
             MigrationState::Version(4),
         )
@@ -170,7 +164,6 @@ mod tests {
 
         let new_storage = Storage::open(
             path,
-            Arc::new(Mutex::new(JoinSet::new())),
             Arc::new(RequestErrorDurationMetrics::new()),
             MigrationState::Version(4),
         )

--- a/rocks-db/tests/parameters_tests.rs
+++ b/rocks-db/tests/parameters_tests.rs
@@ -4,7 +4,7 @@ mod tests {
     use rocks_db::columns::parameters::Parameter;
     use setup::rocks::*;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_get_raw_block_on_empty_db() {
         let storage = RocksTestEnvironment::new(&[]).storage;
@@ -22,7 +22,7 @@ mod tests {
         assert!(response == Some(last_fetched_slot));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_merge_top_seen_slot() {
         let storage = RocksTestEnvironment::new(&[]).storage;

--- a/rocks-db/tests/raw_block_tests.rs
+++ b/rocks-db/tests/raw_block_tests.rs
@@ -6,7 +6,7 @@ mod tests {
 
     const RAW_BLOCK_DEPRECATED_CF_NAME: &str = "RAW_BLOCK_CBOR_ENCODED";
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_raw_block_encoding() {
         // case 1: mock data
         let raw_block_deprecated = RawBlockDeprecated {
@@ -51,7 +51,7 @@ mod tests {
         assert_eq!(RawBlock::decode(&encoded).unwrap(), raw_block);
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_raw_block_migration() {
         let env1 = RocksTestEnvironment::new(&[]);
         let raw_block_deprecated = RawBlockDeprecated {

--- a/rocks-db/tests/signature_client_tests.rs
+++ b/rocks-db/tests/signature_client_tests.rs
@@ -5,7 +5,7 @@ mod tests {
     use setup::rocks::*;
     use solana_sdk::{pubkey::Pubkey, signature::Signature};
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_first_persisted_signature_for_empty_db() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let program_id = Pubkey::new_unique();
@@ -16,7 +16,7 @@ mod tests {
         assert!(response.is_none());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_persist_and_get_first_for_different_keys() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let first_program_id = Pubkey::new_unique();
@@ -63,7 +63,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_drop_signatures_before_for_empty_db() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let program_id = Pubkey::new_unique();
@@ -72,7 +72,7 @@ mod tests {
         assert!(response.is_ok());
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_drop_signatures_before_on_generated_records_for_2_accounts() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let first_program_id = Pubkey::new_unique();
@@ -132,7 +132,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     async fn test_drop_signatures_before_in_the_same_slot_faking_signature() {
         let storage = RocksTestEnvironment::new(&[]).storage;
         let first_program_id = Pubkey::new_unique();

--- a/rocks-db/tests/urls_to_download_test.rs
+++ b/rocks-db/tests/urls_to_download_test.rs
@@ -5,7 +5,7 @@ mod tests {
     use setup::{await_async_for, rocks::*};
     use solana_sdk::keccak;
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_get_urls_to_download() {
         // prepare
@@ -37,7 +37,7 @@ mod tests {
         );
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_successful_download() {
         // prepare
@@ -64,7 +64,7 @@ mod tests {
         assert_eq!(preview_rul, Some(AssetPreviews { size: 400, failed: None }))
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_submit_absent_url() {
         // prepare
@@ -80,7 +80,7 @@ mod tests {
         storage.submit_download_results(vec![download_result]).unwrap();
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread")]
     #[tracing_test::traced_test]
     async fn test_remove_url_after_max_failed_attempts_to_dwonload() {
         // prepare

--- a/tests/setup/Cargo.toml
+++ b/tests/setup/Cargo.toml
@@ -15,6 +15,7 @@ solana-sdk = { workspace = true }
 tempfile = { workspace = true }
 rand = { workspace = true }
 tokio = { workspace = true }
+tokio-util = { workspace = true }
 sqlx = { workspace = true }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }

--- a/tests/txn_forwarder/src/utils.rs
+++ b/tests/txn_forwarder/src/utils.rs
@@ -24,7 +24,7 @@ pub fn find_sigs<'a>(
 ) -> Result<(JoinHandle<Result<(), String>>, UnboundedReceiver<String>), String> {
     let mut last_sig = None;
     let (tx, rx) = mpsc::unbounded_channel::<String>();
-    let jh = tokio::spawn(async move {
+    let jh = usecase::executor::spawn(async move {
         loop {
             let before = last_sig;
             let sigs = client

--- a/usecase/Cargo.toml
+++ b/usecase/Cargo.toml
@@ -34,3 +34,4 @@ bubblegum-batch-sdk = { workspace = true }
 solana-storage-proto = { workspace = true }
 prost = "0.11.9"
 futures = { workspace = true }
+tokio-util = { workspace = true }

--- a/usecase/src/executor.rs
+++ b/usecase/src/executor.rs
@@ -1,0 +1,27 @@
+use std::{future::Future, sync::OnceLock};
+
+use tokio::{
+    sync::Mutex,
+    task::{AbortHandle, JoinSet},
+};
+
+pub static EXECUTOR: Mutex<OnceLock<JoinSet<()>>> = Mutex::const_new(OnceLock::new());
+
+pub fn spawn<T, F: Future<Output = T> + Send + 'static>(future: F) -> AbortHandle {
+    tokio::task::block_in_place(|| {
+        let mut executor_guard = EXECUTOR.blocking_lock();
+        let _ = executor_guard.get_or_init(JoinSet::new);
+        let executor =
+            executor_guard.get_mut().expect("executor join set to be initialized upon access");
+        executor.spawn(async move {
+            let _ = future.await;
+        })
+    })
+}
+
+pub(crate) async fn shutdown() {
+    let mut executor_guard = EXECUTOR.lock().await;
+    let executor =
+        executor_guard.get_mut().expect("executor join set to be initialized upon access");
+    while executor.join_next().await.is_some() {}
+}

--- a/usecase/src/lib.rs
+++ b/usecase/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod asset_streamer;
 pub mod bigtable;
+pub mod executor;
 pub mod graceful_stop;
 pub mod merkle_tree;
 pub mod proofs;


### PR DESCRIPTION
Overhaul task spawning in all modules. Remove usage of the `mutexed_tasks` concept, remove usage of a broadcast channel that was used for shutdown, create a static executor to save running tasks & exit gracefully.