### PR TITLE
fix(api): reorder `SearchAssets` fields to comply with V0 repr

### DIFF
--- a/entities/src/api_req_params.rs
+++ b/entities/src/api_req_params.rs
@@ -273,7 +273,6 @@ pub struct SearchAssets {
     pub royalty_target_type: Option<RoyaltyModel>,
     pub royalty_target: Option<String>,
     pub royalty_amount: Option<u32>,
-    pub token_type: Option<TokenType>,
     pub burnt: Option<bool>,
     pub sort_by: Option<AssetSorting>,
     pub limit: Option<u32>,
@@ -292,6 +291,7 @@ pub struct SearchAssets {
     pub name: Option<String>,
     #[serde(default)]
     pub options: SearchAssetsOptions,
+    pub token_type: Option<TokenType>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]

--- a/entities/src/api_req_params.rs
+++ b/entities/src/api_req_params.rs
@@ -291,6 +291,7 @@ pub struct SearchAssets {
     pub name: Option<String>,
     #[serde(default)]
     pub options: SearchAssetsOptions,
+    #[serde(default)]
     pub token_type: Option<TokenType>,
 }
 

--- a/nft_ingester/tests/api_tests.rs
+++ b/nft_ingester/tests/api_tests.rs
@@ -4212,5 +4212,24 @@ mod tests {
             Into::<GetAsset>::into(params_deserialized),
             GetAsset { id: "asset".to_owned(), options: Default::default() }
         );
+
+        // searchAssets
+        let request_params = r#"[null,"all",null,"pB6sjL2WCbbU654j7pqYbY3hoiMYMYCaa7qnD5qeJ2E",null,null,null,null,null,null,null,null,null,true,null,null,null,null,null,null,153,2,null,null,null]"#;
+        let rpc_params: jsonrpc_core::Params =
+            serde_json::from_str(request_params).expect("params are valid json");
+        let params_deserialized: SearchAssets = rpc_params
+            .parse()
+            .expect("params provided deserialize correctly into GetAssetsByOwner");
+        assert_eq!(
+            params_deserialized,
+            SearchAssets {
+                condition_type: Some(entities::api_req_params::SearchConditionType::All),
+                owner_address: Some("pB6sjL2WCbbU654j7pqYbY3hoiMYMYCaa7qnD5qeJ2E".to_owned()),
+                compressed: Some(true),
+                limit: Some(153),
+                page: Some(2),
+                ..Default::default()
+            }
+        );
     }
 }


### PR DESCRIPTION
Move the `token_type` field in `SeachAssets` to the end of the struct in order to not break pagination on V0 representation (positional JSON case).

This is a **breaking change** for users of positional JSON of V1 variant, but positional JSON seems to not be publicly used outside of umi.