### PR TITLE
fix: Fix error message if collection not found in GetNftEditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6450,16 +6450,15 @@ name = "rocks-db"
 version = "0.6.1-dev"
 dependencies = [
  "Inflector",
- "async-channel 2.3.1",
  "async-trait",
  "base64 0.21.7",
  "bincode",
+ "bs58 0.4.0",
  "chrono",
  "clap 4.5.32",
  "criterion",
  "csv",
  "entities",
- "figment",
  "flatbuffers 24.12.23",
  "futures",
  "futures-util",

--- a/entities/src/api_req_params.rs
+++ b/entities/src/api_req_params.rs
@@ -176,7 +176,7 @@ pub struct GetAssetsByOwner {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
-#[serde(deny_unknown_fields, rename_all = "camelCase")]
+#[serde(deny_unknown_fields)]
 pub struct GetNftEditions {
     pub mint: String,
     pub limit: Option<u32>,

--- a/nft_ingester/src/api/error.rs
+++ b/nft_ingester/src/api/error.rs
@@ -24,6 +24,8 @@ pub enum DasApiError {
     PaginationEmptyError,
     #[error("Batch Size Error. Batch size should not be greater than {0}.")]
     BatchSizeError(usize),
+    #[error("Not Found: {0}")]
+    NotFound(String),
     #[error("RocksDB error: {0}")]
     RocksError(String),
     #[error("No data found.")]
@@ -54,6 +56,11 @@ impl From<DasApiError> for jsonrpc_core::Error {
             DasApiError::PubkeyValidationError(key) => jsonrpc_core::Error {
                 code: ErrorCode::ServerError(STANDARD_ERROR_CODE),
                 message: format!("Pubkey Validation Error: {key} is invalid"),
+                data: None,
+            },
+            DasApiError::NotFound(message) => jsonrpc_core::Error {
+                code: ErrorCode::ServerError(STANDARD_ERROR_CODE),
+                message: format!("Not found: {message}"),
                 data: None,
             },
             DasApiError::PaginationError => jsonrpc_core::Error {
@@ -124,6 +131,7 @@ impl From<StorageError> for DasApiError {
         match value {
             StorageError::CannotServiceRequest => Self::CannotServiceRequest,
             StorageError::QueryTimedOut => Self::QueryTimedOut,
+            StorageError::NotFound(message) => Self::NotFound(message),
             e => Self::RocksError(e.to_string()),
         }
     }

--- a/nft_ingester/src/bin/explorer/readme.md
+++ b/nft_ingester/src/bin/explorer/readme.md
@@ -58,7 +58,7 @@ cargo build --release --bin explorer
 Run the compiled binary with the required arguments:
 
 ```bash
-../target/release/explorer --primary-db-path /path/to/your/primary/db 
+./target/release/explorer --primary-db-path /path/to/your/primary/db 
 ```
 ### Optional Arguments
 
@@ -96,7 +96,7 @@ The service accepts the following command-line arguments:
 
 #### Example Request:
 ```bash
-curl "http://localhost:8086/iterate_keys?cf_name=default&limit=5"
+curl "http://localhost:8086/iterate_keys?cf_name=ASSET_LEAF_V2&limit=5"
 ```
 
 ### Get Value

--- a/rocks-db/Cargo.toml
+++ b/rocks-db/Cargo.toml
@@ -14,7 +14,6 @@ bincode = { workspace = true }
 serde = { workspace = true }
 thiserror = { workspace = true }
 num_cpus = { workspace = true }
-figment = { workspace = true }
 lz4 = { workspace = true }
 tar = { workspace = true }
 reqwest = { workspace = true }
@@ -28,7 +27,6 @@ serde_json = { workspace = true }
 mockall = { workspace = true }
 async-trait = { workspace = true }
 tokio-stream = { workspace = true }
-async-channel = { workspace = true }
 entities = { path = "../entities" }
 interface = { path = "../interface" }
 solana-transaction-status = { workspace = true }
@@ -47,6 +45,7 @@ num-traits = { workspace = true }
 flatbuffers = { version="24.3.25", features = ["serialize"]} 
 indicatif = { workspace = true }
 tokio-util = { workspace = true }
+bs58 = { workspace = true }
 
 [dev-dependencies]
 rand = { workspace = true }

--- a/rocks-db/src/clients/asset_client.rs
+++ b/rocks-db/src/clients/asset_client.rs
@@ -424,7 +424,7 @@ impl Storage {
 
         let master_edition_metadata = match master_edition_metadata? {
             Some(TokenMetadataEdition::MasterEdition(metadata)) => metadata,
-            _ => return Err(StorageError::Common("Expected MasterEdition".to_string())),
+            _ => return Err(StorageError::NotFound("Expected MasterEdition".to_string())),
         };
 
         let asset_edition_info_list: Vec<AssetEditionInfo> = asset_edition_child_assets?

--- a/rocks-db/src/key_encoders.rs
+++ b/rocks-db/src/key_encoders.rs
@@ -156,7 +156,7 @@ pub fn encode_pubkeyx3(ask: (Pubkey, Pubkey, Pubkey)) -> Vec<u8> {
 
 #[cfg(test)]
 mod tests {
-    use solana_sdk::pubkey::Pubkey;
+    use solana_sdk::{bs58, pubkey::Pubkey};
 
     // Import functions from the parent module
     use super::*;
@@ -207,6 +207,20 @@ mod tests {
 
         assert_eq!(decoded.0, pubkey);
         assert_eq!(decoded.1, slot);
+    }
+
+    #[test]
+    fn test_encode_pubkey_u64_from_str() {
+        let key_str = "169iCHteiFuE3ksp4GGo2ZP1gB5tRPJfdeSTzPgrmynbKbWWcxzD2Y";
+        let key_bytes = bs58::decode(key_str).into_vec().unwrap();
+
+        let decoded = decode_pubkey_u64(key_bytes).unwrap();
+
+        assert_eq!(
+            decoded.0,
+            Pubkey::try_from("17ycUSjxhN3cXM922EQnzjcRjNGDngd9jPQaka7DmTQ").unwrap()
+        );
+        assert_eq!(decoded.1, 1);
     }
 
     #[test]


### PR DESCRIPTION
- Updated error handling to provide a clearer message when a collection is not found in the GetNftEditions function.
- Add test to convert data from string in to pubkey_u64
- Removed unused cargo dependencies from the rocks-db